### PR TITLE
Sécurité (IDOR factures + prestations) et mise en place CI/CD

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,56 @@
+# ─────────────────────────────────────────────────────────────
+# Modèle du .env de PRODUCTION (à placer dans /var/www/ProMeb/.env sur le VPS)
+# Ce fichier sert à la fois :
+#   - à l'interpolation de docker-compose.production.yml (APP_KEY, MYSQL_*)
+#   - au cache de config Laravel (docker cp .env → config:cache)
+# Ne jamais commiter le .env réel — seulement ce modèle.
+# ─────────────────────────────────────────────────────────────
+
+APP_NAME=ProMeb
+APP_ENV=production
+APP_KEY=                      # généré au premier déploiement (php artisan key:generate)
+APP_DEBUG=false
+APP_URL=https://promeb.hotel-longchamps.fr
+
+APP_LOCALE=fr
+APP_FALLBACK_LOCALE=fr
+APP_FAKER_LOCALE=fr_FR
+
+# Logs vers stdout/stderr du container (visibles via docker logs / Dozzle)
+LOG_CHANNEL=stderr
+LOG_STACK=single
+LOG_LEVEL=error
+
+# Base de données — doit correspondre au service promeb_db du compose
+DB_CONNECTION=mysql
+DB_HOST=promeb_db
+DB_PORT=3306
+DB_DATABASE=promeb
+DB_USERNAME=promeb
+DB_PASSWORD=change_me
+
+# Variables consommées par docker-compose.production.yml (service mysql)
+MYSQL_DATABASE=promeb
+MYSQL_USER=promeb
+MYSQL_PASSWORD=change_me
+MYSQL_ROOT_PASSWORD=change_me_root
+
+# Session / Sanctum (auth SPA par cookie) — indispensable en prod
+SESSION_DRIVER=database
+SESSION_LIFETIME=120
+SESSION_DOMAIN=promeb.hotel-longchamps.fr
+SANCTUM_STATEFUL_DOMAINS=promeb.hotel-longchamps.fr
+
+CACHE_STORE=database
+QUEUE_CONNECTION=database
+
+# Mail (envoi des factures) — à renseigner selon le fournisseur SMTP
+MAIL_MAILER=smtp
+MAIL_HOST=
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_FROM_ADDRESS="no-reply@promeb.hotel-longchamps.fr"
+MAIL_FROM_NAME="${APP_NAME}"
+
+VITE_APP_NAME="${APP_NAME}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    name: Tests (Pest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout du code
+        uses: actions/checkout@v4
+
+      - name: Installation de PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo, pdo_sqlite, mbstring, zip, exif, pcntl, gd, bcmath, intl
+          coverage: none
+
+      - name: Cache des dépendances Composer
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Installation des dépendances Composer
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Préparation de l'environnement
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Exécution des tests
+        run: php artisan test --testsuite=Feature

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: CD
+
+# Déclenché uniquement lorsque la CI a réussi sur main.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Déploiement VPS Infine
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Déploiement via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USERNAME }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: bash /var/www/ProMeb/deploy.sh

--- a/app/Policies/FacturePolicy.php
+++ b/app/Policies/FacturePolicy.php
@@ -8,6 +8,22 @@ use App\Models\User;
 class FacturePolicy
 {
     /**
+     * L'utilisateur peut consulter une facture (ex: PDF) **s'il en est le propriétaire**.
+     */
+    public function view(User $user, Facture $facture): bool
+    {
+        return $user->id === $facture->user_id;
+    }
+
+    /**
+     * L'utilisateur peut modifier une facture (ex: marquer payée) **s'il en est le propriétaire**.
+     */
+    public function update(User $user, Facture $facture): bool
+    {
+        return $user->id === $facture->user_id;
+    }
+
+    /**
      * L'utilisateur peut supprimer une facture **s'il en est le propriétaire**.
      */
     public function delete(User $user, Facture $facture): bool

--- a/app/Policies/PrestationPolicy.php
+++ b/app/Policies/PrestationPolicy.php
@@ -8,19 +8,21 @@ use App\Models\User;
 class PrestationPolicy
 {
     /**
-     * L'utilisateur peut mettre à jour une prestation **s'il en est le propriétaire**.
+     * L'utilisateur peut mettre à jour une prestation **s'il en est le propriétaire**
+     * et **tant qu'elle n'est pas déjà rattachée à une facture**.
      */
     public function update(User $user, Prestation $prestation): bool
     {
-        return !$prestation->facture_id;
+        return $user->id === $prestation->user_id && !$prestation->facture_id;
     }
 
     /**
-     * L'utilisateur peut supprimer une prestation **s'il en est le propriétaire**.
+     * L'utilisateur peut supprimer une prestation **s'il en est le propriétaire**
+     * et **tant qu'elle n'est pas déjà rattachée à une facture**.
      */
     public function delete(User $user, Prestation $prestation): bool
     {
-        return !$prestation->facture_id;
+        return $user->id === $prestation->user_id && !$prestation->facture_id;
     }
 }
 

--- a/app/Services/FactureService.php
+++ b/app/Services/FactureService.php
@@ -28,9 +28,19 @@ class FactureService extends BaseService
     {
         return $this->handleExceptions(function () use ($data) {
             return DB::transaction(function () use ($data) {
-                $prestations = Prestation::whereIn('id', $data['prestations'])
+                $ids = $data['prestations'];
+
+                $prestations = Prestation::whereIn('id', $ids)
+                                    ->where('user_id', Auth::id())
                                     ->with('tauxHoraire')
                                     ->get();
+
+                // Vérifier que toutes les prestations demandées appartiennent bien à l'utilisateur
+                if ($prestations->count() !== count(array_unique($ids))) {
+                    throw ValidationException::withMessages([
+                        'prestations' => "Une ou plusieurs prestations sélectionnées n'existent pas ou ne vous appartiennent pas.",
+                    ]);
+                }
 
                 // Vérifier si toutes les prestations appartiennent au même client
                 $clients = $prestations->groupBy('client_id');
@@ -48,7 +58,8 @@ class FactureService extends BaseService
                     'statut'        => FactureStatut::EnAttentePaiement,
                 ]);
 
-                Prestation::whereIn('id', $data['prestations'])
+                Prestation::whereIn('id', $ids)
+                    ->where('user_id', Auth::id())
                     ->update(['facture_id' => $facture->id]);
 
                 return $facture->refresh()->load('prestations.client', 'prestations.tauxHoraire');

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Client>
+ */
+class ClientFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'nom'         => $this->faker->company(),
+            'adresse'     => $this->faker->streetAddress(),
+            'code_postal' => $this->faker->postcode(),
+            'ville'       => $this->faker->city(),
+            'pays'        => 'France',
+            'siren'       => (string) $this->faker->numberBetween(100000000, 999999999),
+            'user_id'     => User::factory(),
+        ];
+    }
+}

--- a/database/factories/FactureFactory.php
+++ b/database/factories/FactureFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\FactureStatut;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Facture>
+ */
+class FactureFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'heures_total'  => $this->faker->numberBetween(1, 40),
+            'montant_total' => $this->faker->numberBetween(100, 5000),
+            'statut'        => FactureStatut::EnAttentePaiement,
+            'user_id'       => User::factory(),
+        ];
+    }
+}

--- a/database/factories/PrestationFactory.php
+++ b/database/factories/PrestationFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories;
 
+use App\Models\Client;
+use App\Models\TauxHoraire;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -23,6 +25,8 @@ class PrestationFactory extends Factory
             'adresse'   => $this->faker->address(),
             'horaires'  => $this->faker->time(),
             'user_id'   => User::factory(),
+            'client_id' => Client::factory(),
+            'taux_horaire_id' => TauxHoraire::factory(),
         ];
     }
 }

--- a/database/factories/TauxHoraireFactory.php
+++ b/database/factories/TauxHoraireFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TauxHoraire>
+ */
+class TauxHoraireFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'taux'    => $this->faker->numberBetween(20, 120),
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Script de déploiement ProMeb — exécuté sur le VPS Infine par le workflow CD (SSH).
+# Prérequis sur le VPS : un fichier .env de production présent dans APP_DIR
+# (voir .env.production.example pour les variables attendues).
+#
+set -euo pipefail
+
+APP_DIR="/var/www/ProMeb"
+COMPOSE="docker compose -f docker-compose.production.yml"
+APP_CONTAINER="promeb_app"
+
+cd "$APP_DIR"
+
+echo "▶ 1/8 — Récupération du code"
+git pull origin main
+
+echo "▶ 2/8 — Build des images"
+$COMPOSE build
+
+echo "▶ 3/8 — Démarrage des containers"
+$COMPOSE up -d
+
+echo "▶ 4/8 — Injection du .env dans le container Laravel"
+docker cp .env "${APP_CONTAINER}:/var/www/html/.env"
+docker exec -u root "$APP_CONTAINER" chown www-data:www-data /var/www/html/.env
+
+echo "▶ 5/8 — Nettoyage du cache de config (valeurs potentiellement obsolètes)"
+$COMPOSE exec -T "$APP_CONTAINER" php artisan config:clear
+
+echo "▶ 6/8 — Attente de la disponibilité de MySQL"
+until $COMPOSE exec -T "$APP_CONTAINER" php artisan db:show > /dev/null 2>&1; do
+    echo "   …MySQL indisponible, nouvelle tentative dans 3s"
+    sleep 3
+done
+
+echo "▶ 7/8 — Génération de la clé applicative (première fois uniquement)"
+if ! grep -q "^APP_KEY=base64:" .env; then
+    APP_KEY=$($COMPOSE exec -T "$APP_CONTAINER" php artisan key:generate --show)
+    sed -i "s|^APP_KEY=.*|APP_KEY=${APP_KEY}|" .env
+    docker cp .env "${APP_CONTAINER}:/var/www/html/.env"
+    docker exec -u root "$APP_CONTAINER" chown www-data:www-data /var/www/html/.env
+fi
+
+echo "   → Migrations"
+$COMPOSE exec -T "$APP_CONTAINER" php artisan migrate --force
+
+echo "   → Permissions storage / bootstrap cache"
+docker exec -u root "$APP_CONTAINER" chown -R www-data:www-data storage bootstrap/cache
+
+echo "▶ 8/8 — Mise en cache Laravel (après .env complet + migrations)"
+$COMPOSE exec -T "$APP_CONTAINER" php artisan config:cache
+$COMPOSE exec -T "$APP_CONTAINER" php artisan route:cache
+$COMPOSE exec -T "$APP_CONTAINER" php artisan view:cache
+
+echo "✅ Déploiement terminé"

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,7 +9,6 @@ use App\Http\Controllers\API\TauxHoraireController;
 use App\Http\Controllers\API\UserController;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
-use SebastianBergmann\CodeCoverage\Report\Html\Dashboard;
 
 Route::middleware('auth:sanctum')->group(function () {
 
@@ -88,10 +87,12 @@ Route::middleware('auth:sanctum')->group(function () {
                 ->middleware('can:delete,facture');
             
             Route::get('/{facture}/pdf', [FactureController::class, 'pdf'])
-                ->name('pdf');
+                ->name('pdf')
+                ->middleware('can:view,facture');
 
             Route::patch('/{facture}/paid', [FactureController::class, 'paid'])
-                ->name('paid');
+                ->name('paid')
+                ->middleware('can:update,facture');
         });
 
         Route::prefix('dashboard')

--- a/tests/Feature/FactureSecurityTest.php
+++ b/tests/Feature/FactureSecurityTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Facture;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Crée une prestation cohérente (même propriétaire pour user/client/taux) rattachée à une facture.
+ */
+function prestationPour(User $user, ?Facture $facture = null): Prestation
+{
+    return Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => Client::factory()->create(['user_id' => $user->id])->id,
+        'taux_horaire_id' => TauxHoraire::factory()->create(['user_id' => $user->id])->id,
+        'facture_id'      => $facture?->id,
+    ]);
+}
+
+// ─── Faille #1 : téléchargement du PDF d'autrui (IDOR) ───────────────────────
+
+it('interdit de télécharger le PDF de la facture d\'un autre utilisateur', function () {
+    $proprietaire = User::factory()->create();
+    $facture = Facture::factory()->create(['user_id' => $proprietaire->id]);
+    prestationPour($proprietaire, $facture);
+
+    $intrus = User::factory()->create();
+
+    $this->actingAs($intrus)
+        ->getJson(route('factures.pdf', $facture))
+        ->assertForbidden();
+});
+
+// ─── Faille #2 : marquer payée la facture d'autrui (IDOR) ────────────────────
+
+it('interdit de marquer payée la facture d\'un autre utilisateur', function () {
+    $proprietaire = User::factory()->create();
+    $facture = Facture::factory()->create(['user_id' => $proprietaire->id]);
+
+    $intrus = User::factory()->create();
+
+    $this->actingAs($intrus)
+        ->patchJson(route('factures.paid', $facture))
+        ->assertForbidden();
+
+    expect($facture->fresh()->paye_le)->toBeNull();
+});
+
+// ─── Faille #3 : créer une facture depuis les prestations d'autrui (IDOR) ─────
+
+it('interdit de créer une facture depuis les prestations d\'un autre utilisateur', function () {
+    $victime = User::factory()->create();
+    $prestationVictime = prestationPour($victime);
+
+    $intrus = User::factory()->create();
+
+    $this->actingAs($intrus)
+        ->postJson(route('factures.store'), [
+            'prestations' => [$prestationVictime->id],
+        ])
+        ->assertStatus(422);
+
+    // La prestation de la victime ne doit pas avoir été réassignée.
+    expect($prestationVictime->fresh()->facture_id)->toBeNull();
+    expect(Facture::where('user_id', $intrus->id)->count())->toBe(0);
+});
+
+// ─── Non-régression : le propriétaire garde ses accès légitimes ──────────────
+
+it('autorise le propriétaire à marquer sa facture payée', function () {
+    $user = User::factory()->create();
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->patchJson(route('factures.paid', $facture))
+        ->assertOk()
+        ->assertJson(['message' => 'La facture a été payée avec succès']);
+
+    expect($facture->fresh()->paye_le)->not->toBeNull();
+});
+
+it('autorise le propriétaire à créer une facture depuis ses propres prestations', function () {
+    $user = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 50]);
+
+    $p1 = Prestation::factory()->create([
+        'user_id' => $user->id, 'client_id' => $client->id, 'taux_horaire_id' => $taux->id, 'heures' => 2,
+    ]);
+    $p2 = Prestation::factory()->create([
+        'user_id' => $user->id, 'client_id' => $client->id, 'taux_horaire_id' => $taux->id, 'heures' => 3,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('factures.store'), ['prestations' => [$p1->id, $p2->id]])
+        ->assertCreated()
+        ->assertJson(['message' => 'Facture créée avec succès.']);
+
+    expect($p1->fresh()->facture_id)->not->toBeNull();
+    expect($p2->fresh()->facture_id)->toBe($p1->fresh()->facture_id);
+});

--- a/tests/Feature/PrestationControllerTest.php
+++ b/tests/Feature/PrestationControllerTest.php
@@ -34,12 +34,7 @@ it('récupère les prestations de l\'utilisateur connecté', function () {
  * 🔹 TEST: Création d'une prestation avec des données valides
  */
 it('crée une prestation avec des données valides', function () {
-    $data = [
-        'date'      => now()->toDateString(),
-        'heures'    => 5,
-        'adresse'   => '123 rue du Test',
-        'horaires'  => '10:00-12:00',
-    ];
+    $data = prestationPayload($this->user);
 
     $response = $this->postJson(route('prestations.store'), $data);
 
@@ -69,12 +64,12 @@ it('retourne une erreur 422 si les données sont invalides lors de la création'
 it('met à jour une prestation existante', function () {
     $prestation = Prestation::factory()->create(['user_id' => $this->user->id]);
 
-    $updatedData = [
+    $updatedData = prestationPayload($this->user, [
         'date'      => now()->addDays(5)->toDateString(),
         'heures'    => 3,
         'adresse'   => '456 rue Modifiée',
         'horaires'  => '14:00-16:00',
-    ];
+    ]);
 
     $response = $this->putJson(route('prestations.update', $prestation), $updatedData);
 
@@ -90,12 +85,7 @@ it('retourne une erreur 403 si l\'utilisateur tente de modifier une prestation q
     $autreUser = User::factory()->create();
     $prestation = Prestation::factory()->create(['user_id' => $autreUser->id]);
 
-    $response = $this->putJson(route('prestations.update', $prestation), [
-        'date'      => now()->toDateString(),
-        'heures'    => 3,
-        'adresse'   => 'Nouvelle adresse',
-        'horaires'  => '10:00-12:00',
-    ]);
+    $response = $this->putJson(route('prestations.update', $prestation), prestationPayload($this->user));
 
     $response->assertForbidden();
 });

--- a/tests/Feature/PrestationPolicyTest.php
+++ b/tests/Feature/PrestationPolicyTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Facture;
 use App\Models\Prestation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -32,12 +33,7 @@ it('autorise un utilisateur à créer une prestation', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)
-        ->postJson(route('prestations.store'), [
-            'date'      => now()->toDateString(),
-            'heures'    => 5,
-            'adresse'   => '123 rue du Test',
-            'horaires'  => '10:00-12:00',
-        ])
+        ->postJson(route('prestations.store'), prestationPayload($user))
         ->assertCreated()
         ->assertJson(['message' => 'Prestation créée avec succès.']);
 });
@@ -48,12 +44,11 @@ it('autorise un utilisateur de modifier une prestation qui lui appartient ', fun
     $prestation = Prestation::factory()->create(['user_id' => $user1->id]);
 
     $this->actingAs($user1)
-        ->putJson(route('prestations.update', $prestation), [
-            'date'      => now()->toDateString(),
+        ->putJson(route('prestations.update', $prestation), prestationPayload($user1, [
             'heures'    => 3,
             'adresse'   => '456 rue Modifiée',
             'horaires'  => '14:00-16:00',
-        ])
+        ]))
         ->assertStatus(200)
         ->assertJson(['message' => 'Prestation mise à jour avec succès.']);
 });
@@ -64,12 +59,7 @@ it('interdit un utilisateur de modifier une prestation qui ne lui appartient pas
     $prestation = Prestation::factory()->create(['user_id' => $user1->id]);
 
     $this->actingAs($user2)
-        ->putJson(route('prestations.update', $prestation), [
-            'date'      => now()->toDateString(),
-            'heures'    => 3,
-            'adresse'   => '456 rue Modifiée',
-            'horaires'  => '14:00-16:00',
-        ])
+        ->putJson(route('prestations.update', $prestation), prestationPayload($user2))
         ->assertForbidden()  // ✅ Plus lisible
         ->assertJson(['message' => 'This action is unauthorized.']);
 });
@@ -99,4 +89,30 @@ it('interdit un utilisateur non authentifié d\'accéder aux prestations', funct
     $this->getJson(route('prestations.index'))
         ->assertUnauthorized() // ✅ Vérifie qu'il reçoit un 401 Unauthorized
         ->assertJson(['message' => 'Unauthenticated.']); // Vérifie le message Laravel
+});
+
+it('interdit au propriétaire de modifier une prestation déjà rattachée à une facture', function () {
+    $user = User::factory()->create();
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+    $prestation = Prestation::factory()->create([
+        'user_id'    => $user->id,
+        'facture_id' => $facture->id,
+    ]);
+
+    $this->actingAs($user)
+        ->putJson(route('prestations.update', $prestation), prestationPayload($user))
+        ->assertForbidden();
+});
+
+it('interdit au propriétaire de supprimer une prestation déjà rattachée à une facture', function () {
+    $user = User::factory()->create();
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+    $prestation = Prestation::factory()->create([
+        'user_id'    => $user->id,
+        'facture_id' => $facture->id,
+    ]);
+
+    $this->actingAs($user)
+        ->deleteJson(route('prestations.destroy', $prestation))
+        ->assertForbidden();
 });

--- a/tests/Feature/PrestationRequestTest.php
+++ b/tests/Feature/PrestationRequestTest.php
@@ -47,12 +47,8 @@ it('autorise la création d\'une prestation avec des données valides', function
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    $this->postJson(route('prestations.store'), [
-        'date'      => now()->toDateString(),
-        'heures'    => 5,
-        'adresse'   => '123 rue du Test',
-        'horaires'  => '10:00-12:00',
-    ])->assertCreated()
+    $this->postJson(route('prestations.store'), prestationPayload($user))
+      ->assertCreated()
       ->assertJsonStructure(['message', 'prestation']);
 });
 
@@ -61,12 +57,12 @@ it('autorise la mise à jour d\'une prestation avec des données valides', funct
     $prestation = Prestation::factory()->create(['user_id' => $user->id]);
 
     $this->actingAs($user)
-        ->putJson(route('prestations.update', $prestation), [
+        ->putJson(route('prestations.update', $prestation), prestationPayload($user, [
             'date'      => now()->addDays(5)->toDateString(),
             'heures'    => 8,
             'adresse'   => 'Nouvelle adresse',
             'horaires'  => '12:00-14:00',
-        ])
+        ]))
         ->assertOk()
         ->assertJsonStructure(['message', 'prestation']);
 });

--- a/tests/Feature/PrestationRoutesTest.php
+++ b/tests/Feature/PrestationRoutesTest.php
@@ -24,12 +24,7 @@ it('autorise un utilisateur connecté à accéder aux routes', function () {
     $this->actingAs($user);
 
     $this->getJson(route('prestations.index'))->assertStatus(200);
-    $this->postJson(route('prestations.store'), [
-        'date'      => now()->toDateString(),
-        'heures'    => 5,
-        'adresse'   => '123 rue du Test',
-        'horaires'  => '10:00-12:00',
-    ])->assertStatus(201);
+    $this->postJson(route('prestations.store'), prestationPayload($user))->assertStatus(201);
 });
 
 it('vérifie qu\'une erreur 405 est retournée pour une mauvaise méthode', function () {
@@ -109,12 +104,7 @@ it('empêche un utilisateur de modifier la prestation d\'un autre', function () 
     $prestation = Prestation::factory()->create(['user_id' => $user1->id]);
 
     $this->actingAs($user2)
-        ->putJson(route('prestations.update', $prestation), [
-            'date'      => now()->toDateString(),
-            'heures'    => 3,
-            'adresse'   => 'Adresse modifiée',
-            'horaires'  => '14:00-16:00',
-        ])
+        ->putJson(route('prestations.update', $prestation), prestationPayload($user2))
         ->assertForbidden(); // Devrait renvoyer 403
 });
 
@@ -137,12 +127,12 @@ it('permet la mise à jour correcte d\'une prestation', function () {
     $prestation = Prestation::factory()->create(['user_id' => $user->id]);
 
     $this->actingAs($user)
-        ->putJson(route('prestations.update', $prestation), [
+        ->putJson(route('prestations.update', $prestation), prestationPayload($user, [
             'date'      => now()->addDay()->toDateString(),
             'heures'    => 4,
             'adresse'   => 'Nouvelle adresse',
             'horaires'  => '12:00-14:00',
-        ])
+        ]))
         ->assertStatus(200)
         ->assertJson([
             'message' => 'Prestation mise à jour avec succès.',

--- a/tests/Feature/PrestationServiceTest.php
+++ b/tests/Feature/PrestationServiceTest.php
@@ -30,12 +30,7 @@ it('crée une prestation avec des données valides', function () {
     $user = User::factory()->create();
     Auth::login($user);
 
-    $data = [
-        'date'      => now()->toDateString(),
-        'heures'    => 5,
-        'adresse'   => '123 rue du Test',
-        'horaires'  => '10:00-12:00',
-    ];
+    $data = prestationPayload($user);
 
     $prestation = $this->service->create($data);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -41,7 +41,18 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+/**
+ * Construit un payload de prestation valide dont le client et le taux horaire
+ * appartiennent à l'utilisateur donné (requis par PrestationRequest).
+ */
+function prestationPayload(\App\Models\User $user, array $overrides = []): array
 {
-    // ..
+    return array_merge([
+        'date'            => now()->toDateString(),
+        'heures'          => 5,
+        'adresse'         => '123 rue du Test',
+        'horaires'        => '10:00-12:00',
+        'client_id'       => \App\Models\Client::factory()->create(['user_id' => $user->id])->id,
+        'taux_horaire_id' => \App\Models\TauxHoraire::factory()->create(['user_id' => $user->id])->id,
+    ], $overrides);
 }


### PR DESCRIPTION
## Contexte
Audit du 2026-07-10 : correction de failles IDOR et mise en place de l'intégration/déploiement continus.

## 🔒 Sécurité — failles IDOR corrigées (TDD)
- **Factures** : les routes `pdf` et `paid` n'avaient aucune autorisation (`FacturePolicy` n'avait que `delete`) → n'importe quel utilisateur téléchargeait le PDF (IBAN/SIREN/adresses) ou marquait payée la facture d'autrui. Ajout des abilities `view`/`update` + middlewares `can:`.
- **Création de facture** : `FactureService::create` ne scopait pas les prestations à l'utilisateur → création depuis les prestations d'autrui + réassignation de leur `facture_id`. Scoping `user_id` + `422` si mismatch.
- **Prestations (découvert au passage)** : `PrestationPolicy::update`/`delete` retournaient `!$prestation->facture_id` **sans vérifier le propriétaire** → modification/suppression de la prestation d'autrui. Ajout de la vérification propriétaire (contrainte « non facturée » préservée).

## ✅ Tests
- Nouveau `FactureSecurityTest` (régression IDOR).
- Cause racine des tests Prestation rouges identifiée (factories/tests obsolètes vs schéma exigeant `client_id`/`taux_horaire_id`) et corrigée sans dégrader la prod : factories `Client`/`TauxHoraire`/`Facture` + `PrestationFactory` complétée, helper `prestationPayload()`, tests réalignés + 2 tests métier.
- **Suite complète : 46 tests, 147 assertions — verts** (baseline : 28 rouges).

## ⚙️ CI/CD (GitHub Actions)
- `ci.yml` : tests Pest (PHP 8.4, SQLite en mémoire) sur push/PR `main`.
- `deploy.yml` : déploiement SSH **automatique après CI réussie** (`workflow_run`) → `bash /var/www/ProMeb/deploy.sh`.
- `deploy.sh` : script Docker adapté à l'infra (`promeb_app`, `docker-compose.production.yml`, `exec -T`, chown `-u root`).
- `.env.production.example` : variables du `.env` de prod documentées.

## ⚠️ À faire avant activation du CD
1. Configurer les secrets GitHub : `VPS_HOST`, `VPS_USERNAME`, `VPS_SSH_KEY`.
2. Placer un `.env` de prod complet dans `/var/www/ProMeb/` sur le VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)