### PR TITLE
Heures décimales : gérer les fractions d'heure (6h15, 11h45…)

### DIFF
--- a/app/Models/Facture.php
+++ b/app/Models/Facture.php
@@ -22,6 +22,8 @@ class Facture extends Model
 
     protected $casts = [
         'paye_le' => 'date:Y-m-d',
+        'heures_total' => 'decimal:2',
+        'montant_total' => 'decimal:2',
     ];
 
     protected function casts(): array

--- a/app/Models/Prestation.php
+++ b/app/Models/Prestation.php
@@ -22,6 +22,7 @@ class Prestation extends Model
 
     protected $casts = [
         'date' => 'date:Y-m-d',
+        'heures' => 'decimal:2',
     ];
 
     public function user()

--- a/database/migrations/2026_07_10_000001_change_heures_columns_to_decimal.php
+++ b/database/migrations/2026_07_10_000001_change_heures_columns_to_decimal.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Passe les colonnes d'heures et de montants d'entier à décimal pour
+     * permettre les fractions d'heure (ex. 6,25 h). Conversion sans perte :
+     * les valeurs entières existantes deviennent x.00.
+     */
+    public function up(): void
+    {
+        Schema::table('prestations', function (Blueprint $table) {
+            $table->decimal('heures', 6, 2)->change();
+        });
+
+        Schema::table('factures', function (Blueprint $table) {
+            $table->decimal('heures_total', 8, 2)->default(0)->change();
+            $table->decimal('montant_total', 10, 2)->default(0)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('prestations', function (Blueprint $table) {
+            $table->integer('heures')->change();
+        });
+
+        Schema::table('factures', function (Blueprint $table) {
+            $table->integer('heures_total')->default(0)->change();
+            $table->integer('montant_total')->default(0)->change();
+        });
+    }
+};

--- a/resources/js/components/dashboard/FacturesModal.vue
+++ b/resources/js/components/dashboard/FacturesModal.vue
@@ -134,7 +134,7 @@ const totalHeures = computed(() => {
 });
 
 const totalHT = computed(() => {
-  return props.factures.reduce((total, invoice) => total + invoice.montant_total, 0);
+  return props.factures.reduce((total, invoice) => total + parseFloat(invoice.montant_total), 0);
 });
 
 // 📌 Marquer la facture comme payée avec chargement

--- a/resources/js/components/prestations/PrestationFormModal.vue
+++ b/resources/js/components/prestations/PrestationFormModal.vue
@@ -90,6 +90,8 @@
           <label for="heures" class="block text-sm font-medium text-gray-700">Nombre d'heures</label>
           <input
             type="number"
+            step="0.25"
+            min="0"
             id="heures"
             v-model="prestationData.heures"
             class="w-full border p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"

--- a/resources/js/stores/clients.js
+++ b/resources/js/stores/clients.js
@@ -39,7 +39,7 @@ export const useClientsStore = defineStore('clients', () => {
 
   const totalHours = computed(() => {
     return filteredPrestations.value
-      .reduce((acc, prestation) => acc + prestation.heures, 0)
+      .reduce((acc, prestation) => acc + parseFloat(prestation.heures), 0)
   });
 
   const unbilledPrestations = computed(() => {

--- a/resources/js/stores/prestations.js
+++ b/resources/js/stores/prestations.js
@@ -47,7 +47,7 @@ export const usePrestationsStore = defineStore('prestations', () => {
 
   const totalHours = computed(() => {
     return filteredPrestations.value
-      .reduce((acc, prestation) => acc + prestation.heures, 0)
+      .reduce((acc, prestation) => acc + parseFloat(prestation.heures), 0)
   });
 
   const unbilledPrestations = computed(() => {

--- a/resources/js/stores/taux-horaires.js
+++ b/resources/js/stores/taux-horaires.js
@@ -37,7 +37,7 @@ export const useTauxHorairesStore = defineStore('taux-horaires', () => {
 
   const totalHours = computed(() => {
     return filteredPrestations.value
-      .reduce((acc, prestation) => acc + prestation.heures, 0)
+      .reduce((acc, prestation) => acc + parseFloat(prestation.heures), 0)
   });
 
   const unbilledPrestations = computed(() => {

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -163,7 +163,7 @@
                         <td>{{ $prestation->id }}</td>
                         <td>{{ \Carbon\Carbon::parse($prestation->date)->format('d/m/Y') }}</td>
                         <td>{{ $prestation->horaires }}</td>
-                        <td>{{ $prestation->heures }}</td>
+                        <td>{{ number_format($prestation->heures, 2, ',', ' ') }}</td>
                         <td>{{ number_format($prestation->tauxHoraire->taux ?? 20, 2, ',', ' ') }} €</td>
                         <td>{{ number_format($prestation->heures * ($prestation->tauxHoraire->taux ?? 20), 2, ',', ' ') }} €</td>
                     </tr>

--- a/tests/Feature/PrestationHeuresDecimalTest.php
+++ b/tests/Feature/PrestationHeuresDecimalTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use App\Services\FactureService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+uses(RefreshDatabase::class);
+
+it('stocke et relit des heures fractionnées sans perte', function () {
+    $user = User::factory()->create();
+
+    $prestation = Prestation::factory()->create([
+        'user_id' => $user->id,
+        'heures'  => 6.25,
+    ]);
+
+    // Le cast decimal:2 garantit une représentation exacte et stable (string "6.25").
+    expect($prestation->fresh()->heures)->toBe('6.25');
+});
+
+it('somme les heures et montants décimaux exactement dans la facture', function () {
+    $user = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 20]);
+
+    $p1 = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'heures'          => 6.25,
+    ]);
+    $p2 = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'heures'          => 9.50,
+    ]);
+
+    Auth::login($user);
+    $facture = app(FactureService::class)->create(['prestations' => [$p1->id, $p2->id]]);
+
+    // 6.25 + 9.50 = 15.75 h ; 15.75 × 20 = 315.00 €
+    expect($facture->heures_total)->toBe('15.75');
+    expect($facture->montant_total)->toBe('315.00');
+});

--- a/tests/Feature/PrestationServiceTest.php
+++ b/tests/Feature/PrestationServiceTest.php
@@ -37,7 +37,7 @@ it('crée une prestation avec des données valides', function () {
     expect($prestation)->toBeInstanceOf(Prestation::class);
     expect($prestation->user_id)->toBe($user->id);
     expect($prestation->date->toDateString())->toBe($data['date']); // ✅ Fix ici
-    expect($prestation->heures)->toBe($data['heures']);
+    expect($prestation->heures)->toEqual($data['heures']); // decimal:2 → "5.00" == 5
     expect($prestation->adresse)->toBe($data['adresse']);
     expect($prestation->horaires)->toBe($data['horaires']);
 });
@@ -58,7 +58,7 @@ it('met à jour une prestation existante', function () {
     $updatedPrestation = $this->service->update($prestation, $updatedData);
 
     expect($updatedPrestation->date->toDateString())->toBe($updatedData['date']); // ✅ Fix ici
-    expect($updatedPrestation->heures)->toBe($updatedData['heures']);
+    expect($updatedPrestation->heures)->toEqual($updatedData['heures']); // decimal:2 → "8.00" == 8
     expect($updatedPrestation->adresse)->toBe($updatedData['adresse']);
     expect($updatedPrestation->horaires)->toBe($updatedData['horaires']);
 });


### PR DESCRIPTION
## Contexte
Les freelances saisissent des heures avec des minutes (6h15 = 6,25 h), mais les colonnes d'heures/montants étaient en `integer` → troncature et totaux de facture faux. Prérequis avant le script d'import des prestations de juin.

## Changements
**Migration** (sûre, sans perte, réversible — les entiers existants deviennent `x.00`) :
| Colonne | avant | après |
|---|---|---|
| `prestations.heures` | integer | `decimal(6,2)` |
| `factures.heures_total` | integer | `decimal(8,2)` |
| `factures.montant_total` | integer | `decimal(10,2)` |

- **Casts Eloquent** `decimal:2` sur les 3 colonnes.
- **Front** : `parseFloat` sur les 4 sommes d'heures/montants (le cast `decimal` renvoie une string) ; `step="0.25"` sur le champ « Nombre d'heures » (sinon le navigateur refuse les décimales).
- **PDF** : formatage des heures (`6,25`).

## Tests (TDD)
Nouveau `PrestationHeuresDecimalTest` : conservation de `6,25 h` sans perte + totaux de facture décimaux exacts (`15,75 h` → `315,00 €`). Assertions existantes ajustées.

**Suite complète : 48 tests verts.** Migration `up` + `rollback` validés sur SQLite.

## Déploiement
Merge sur `main` → le CD lance `migrate --force` : la colonne est modifiée sur place, les données de prod sont préservées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)