### PR TITLE
Commande d'import des prestations mensuelles (prestations:import)

### DIFF
--- a/app/Console/Commands/ImportPrestations.php
+++ b/app/Console/Commands/ImportPrestations.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Client;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Services\PrestationTextParser;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\textarea;
+
+class ImportPrestations extends Command
+{
+    protected $signature = 'prestations:import
+        {--client= : ID du client (sinon sélection interactive)}
+        {--taux= : ID du taux horaire (sinon sélection interactive)}
+        {--year= : Année des prestations (défaut : année courante)}
+        {--file= : Chemin d\'un fichier texte (sinon collage interactif)}
+        {--adresse=PARIS : Adresse appliquée à toutes les prestations}
+        {--force : Ne pas demander de confirmation}';
+
+    protected $description = 'Importe en masse des prestations mensuelles depuis le relevé texte d\'un freelance.';
+
+    public function handle(PrestationTextParser $parser): int
+    {
+        $client = $this->resolveClient();
+        if (! $client) {
+            $this->error('Client introuvable.');
+
+            return self::FAILURE;
+        }
+
+        $taux = $this->resolveTaux($client);
+        if (! $taux) {
+            $this->error('Taux horaire introuvable ou n\'appartenant pas au même utilisateur que le client.');
+
+            return self::FAILURE;
+        }
+
+        $year = (int) ($this->option('year') ?: now()->year);
+        $text = $this->resolveText();
+        if (trim($text) === '') {
+            $this->error('Aucun texte à importer.');
+
+            return self::FAILURE;
+        }
+
+        $result = $parser->parse($text, $year);
+
+        if (! empty($result['errors'])) {
+            $this->error('Lignes non interprétables (import annulé) :');
+            foreach ($result['errors'] as $line) {
+                $this->line("  • {$line}");
+            }
+
+            return self::FAILURE;
+        }
+
+        $this->table(
+            ['Date', 'Heures', 'Horaires'],
+            array_map(fn ($r) => [$r['date'], number_format($r['heures'], 2, ',', ' '), $r['horaires']], $result['rows'])
+        );
+        $this->info(sprintf(
+            '%d prestations · %s h · client « %s » · taux %s €/h · adresse « %s »',
+            count($result['rows']),
+            number_format($result['total'], 2, ',', ' '),
+            $client->nom,
+            $taux->taux,
+            $this->option('adresse'),
+        ));
+
+        if (! $this->option('force') && ! confirm('Créer ces prestations ?', default: false)) {
+            $this->comment('Annulé.');
+
+            return self::SUCCESS;
+        }
+
+        DB::transaction(function () use ($result, $client, $taux) {
+            foreach ($result['rows'] as $row) {
+                Prestation::create([
+                    'date'            => $row['date'],
+                    'heures'          => $row['heures'],
+                    'horaires'        => $row['horaires'],
+                    'adresse'         => $this->option('adresse'),
+                    'client_id'       => $client->id,
+                    'taux_horaire_id' => $taux->id,
+                    'user_id'         => $client->user_id,
+                ]);
+            }
+        });
+
+        $this->info(sprintf('✅ %d prestations créées.', count($result['rows'])));
+
+        return self::SUCCESS;
+    }
+
+    private function resolveClient(): ?Client
+    {
+        if ($id = $this->option('client')) {
+            return Client::find($id);
+        }
+
+        $clients = Client::orderBy('nom')->get();
+        if ($clients->isEmpty()) {
+            return null;
+        }
+
+        $id = select('Client ?', $clients->pluck('nom', 'id')->all());
+
+        return $clients->firstWhere('id', $id);
+    }
+
+    private function resolveTaux(Client $client): ?TauxHoraire
+    {
+        if ($id = $this->option('taux')) {
+            $taux = TauxHoraire::find($id);
+
+            return $taux && $taux->user_id === $client->user_id ? $taux : null;
+        }
+
+        $tauxList = TauxHoraire::where('user_id', $client->user_id)->orderBy('taux')->get();
+        if ($tauxList->isEmpty()) {
+            return null;
+        }
+
+        $id = select('Taux horaire ?', $tauxList->mapWithKeys(fn ($t) => [$t->id => "{$t->taux} €/h"])->all());
+
+        return $tauxList->firstWhere('id', $id);
+    }
+
+    private function resolveText(): string
+    {
+        if ($file = $this->option('file')) {
+            return is_readable($file) ? (string) file_get_contents($file) : '';
+        }
+
+        return textarea(
+            label: 'Collez le relevé du freelance',
+            placeholder: "02/06: 6h15 18h30-00h45\n03/06: 9h 11h45-14h45 18h15-00h15\n...",
+            rows: 15,
+        );
+    }
+}

--- a/app/Services/PrestationTextParser.php
+++ b/app/Services/PrestationTextParser.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services;
+
+class PrestationTextParser
+{
+    /**
+     * Analyse le relevé mensuel d'un freelance.
+     *
+     * Format d'une ligne : `13/06: 9h15 11h45-15h 2V 18h45-2h`
+     *  - 1ʳᵉ valeur = total d'heures facturées du jour (`9h15` → 9.25),
+     *  - le reste = plages horaires (les marqueurs `V` sont ignorés),
+     *  - les lignes vides et la ligne « TOTAL » sont ignorées.
+     *
+     * @return array{rows: array<int, array{date:string, heures:float, horaires:string, source:string}>, total: float, errors: array<int, string>}
+     */
+    public function parse(string $text, int $year): array
+    {
+        $rows = [];
+        $errors = [];
+
+        foreach (preg_split('/\r\n|\r|\n/', $text) as $line) {
+            $line = trim($line);
+
+            if ($line === '' || preg_match('/^total\b/i', $line)) {
+                continue;
+            }
+
+            if (! preg_match('/^(\d{1,2})\/(\d{1,2})\s*:\s*(.+)$/', $line, $m)) {
+                $errors[] = $line;
+                continue;
+            }
+
+            [$dd, $mm, $rest] = [(int) $m[1], (int) $m[2], trim($m[3])];
+            $tokens = preg_split('/\s+/', $rest);
+
+            $heures = $this->parseHours(array_shift($tokens));
+            if ($heures === null) {
+                $errors[] = $line;
+                continue;
+            }
+
+            // On retire les marqueurs "V" (ex. 2V, 1V) des plages horaires.
+            $shifts = array_values(array_filter($tokens, fn ($t) => ! preg_match('/^\d*v$/i', $t)));
+
+            $rows[] = [
+                'date'     => sprintf('%04d-%02d-%02d', $year, $mm, $dd),
+                'heures'   => $heures,
+                'horaires' => implode(' ', $shifts),
+                'source'   => sprintf('%02d/%02d', $dd, $mm),
+            ];
+        }
+
+        return [
+            'rows'   => $rows,
+            'total'  => round(array_sum(array_column($rows, 'heures')), 2),
+            'errors' => $errors,
+        ];
+    }
+
+    /** Convertit « 6h15 » → 6.25, « 9h » → 9.0. Renvoie null si le format est invalide. */
+    private function parseHours(string $token): ?float
+    {
+        if (! preg_match('/^(\d+)h(\d{1,2})?$/', $token, $m)) {
+            return null;
+        }
+
+        $minutes = isset($m[2]) && $m[2] !== '' ? (int) $m[2] : 0;
+
+        return round((int) $m[1] + $minutes / 60, 2);
+    }
+}

--- a/tests/Feature/ImportPrestationsCommandTest.php
+++ b/tests/Feature/ImportPrestationsCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function ecrireReleve(string $contenu): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'releve_') . '.txt';
+    file_put_contents($path, $contenu);
+
+    return $path;
+}
+
+it('importe les prestations depuis un fichier pour un client et un taux', function () {
+    $user = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 25]);
+
+    $file = ecrireReleve("02/06: 6h15 18h30-00h45\n13/06: 9h15 11h45-15h 2V 18h45-2h\nTOTAL: 15h30");
+
+    $this->artisan('prestations:import', [
+        '--client' => $client->id,
+        '--taux'   => $taux->id,
+        '--year'   => 2026,
+        '--file'   => $file,
+        '--force'  => true,
+    ])->assertExitCode(0);
+
+    expect(Prestation::where('user_id', $user->id)->count())->toBe(2);
+
+    $p = Prestation::where('date', '2026-06-02')->first();
+    expect($p->heures)->toEqual('6.25');
+    expect($p->adresse)->toBe('PARIS');
+    expect($p->client_id)->toBe($client->id);
+    expect($p->taux_horaire_id)->toBe($taux->id);
+
+    // Les marqueurs V sont retirés des horaires.
+    expect(Prestation::where('date', '2026-06-13')->first()->horaires)->toBe('11h45-15h 18h45-2h');
+
+    unlink($file);
+});
+
+it('refuse l\'import si une ligne est illisible et ne crée rien', function () {
+    $user = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $file = ecrireReleve("02/06: 6h15 18h30-00h45\nligne cassée");
+
+    $this->artisan('prestations:import', [
+        '--client' => $client->id,
+        '--taux'   => $taux->id,
+        '--year'   => 2026,
+        '--file'   => $file,
+        '--force'  => true,
+    ])->assertExitCode(1);
+
+    expect(Prestation::count())->toBe(0);
+
+    unlink($file);
+});
+
+it('refuse un taux qui n\'appartient pas au même utilisateur que le client', function () {
+    $client = Client::factory()->create();
+    $tauxAutre = TauxHoraire::factory()->create(); // autre utilisateur
+
+    $file = ecrireReleve('02/06: 6h15 18h30-00h45');
+
+    $this->artisan('prestations:import', [
+        '--client' => $client->id,
+        '--taux'   => $tauxAutre->id,
+        '--year'   => 2026,
+        '--file'   => $file,
+        '--force'  => true,
+    ])->assertExitCode(1);
+
+    expect(Prestation::count())->toBe(0);
+
+    unlink($file);
+});

--- a/tests/Feature/PrestationTextParserTest.php
+++ b/tests/Feature/PrestationTextParserTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Services\PrestationTextParser;
+
+function parseText(string $text, int $year = 2026): array
+{
+    return (new PrestationTextParser())->parse($text, $year);
+}
+
+it('parse une journée simple (date, heures décimales, horaires)', function () {
+    $result = parseText('02/06: 6h15 18h30-00h45');
+
+    expect($result['rows'])->toHaveCount(1);
+    expect($result['rows'][0])->toMatchArray([
+        'date'     => '2026-06-02',
+        'heures'   => 6.25,
+        'horaires' => '18h30-00h45',
+        'source'   => '02/06',
+    ]);
+    expect($result['total'])->toBe(6.25);
+    expect($result['errors'])->toBeEmpty();
+});
+
+it('concatène plusieurs plages dans horaires et convertit les heures pleines', function () {
+    $result = parseText('03/06: 9h 11h45-14h45 18h15-00h15');
+
+    expect($result['rows'][0]['heures'])->toBe(9.0);
+    expect($result['rows'][0]['horaires'])->toBe('11h45-14h45 18h15-00h15');
+});
+
+it('ignore les marqueurs V dans les horaires et ne les compte pas', function () {
+    $result = parseText('13/06: 9h15 11h45-15h 2V 18h45-2h');
+
+    expect($result['rows'][0]['heures'])->toBe(9.25);
+    expect($result['rows'][0]['horaires'])->toBe('11h45-15h 18h45-2h');
+});
+
+it('ignore les lignes vides et la ligne TOTAL', function () {
+    $result = parseText("02/06: 6h15 18h30-00h45\n\nTOTAL: 244h");
+
+    expect($result['rows'])->toHaveCount(1);
+    expect($result['errors'])->toBeEmpty();
+});
+
+it('signale les lignes non interprétables sans planter', function () {
+    $result = parseText("02/06: 6h15 18h30-00h45\nligne cassée sans date");
+
+    expect($result['rows'])->toHaveCount(1);
+    expect($result['errors'])->toHaveCount(1);
+});
+
+it('parse le mois de juin complet et totalise 238 heures', function () {
+    $result = parseText(juinAdjusté());
+
+    expect($result['rows'])->toHaveCount(25);
+    expect($result['errors'])->toBeEmpty();
+    expect($result['total'])->toBe(238.0);
+});
+
+/** Texte de juin 2026 ajusté à 238 h (13/06→9h15, 16/06→9h, 30/06→7h ; V retirés). */
+function juinAdjusté(): string
+{
+    return <<<TXT
+    02/06: 6h15 18h30-00h45
+    03/06: 9h 11h45-14h45 18h15-00h15
+    04/06: 10h15 11h45-14h45 18h15-1h30
+    05/06: 6h30 11h45-14h 20h-2h15
+    06/06: 7h 18h45-1h45
+    08/06: 10h 11h45-14h30 18h45-00h45
+    09/06: 10h 11h45-14h30 18h15-1h15
+    11/06: 6h30 18h45-1h15
+    12/06: 11h15 11h45-15h45 18h45-2h
+    13/06: 9h15 11h45-15h 18h45-2h
+    14/06: 11h 11h45-15h45 18h45-1h45
+    15/06: 10h 11h45-14h45 18h45-1h45
+    16/06: 9h 11h45-14h45 18h15-1h
+    17/06: 11h 11h45-15h45 18h45-1h45
+    18/06: 12h 11h45-15h45 18h15-1h45
+    19/06: 10h45 11h45-15h15 18h45-2h00
+    20/06: 10h15 11h45-14h30 18h15-1h45
+    21/06: 7h 18h15-1h15
+    23/06: 8h 11h45-14h45 18h15-23h15
+    24/06: 10h15 11h45-14h45 18h15-1h15
+    26/06: 10h 12h35-14h45 18h45-1h45
+    27/06: 12h 11h45-17h 18h45-2h
+    28/06: 12h15 11h45-16h45 18h45-1h
+    29/06: 11h30 11h45-16h45 18h45-1h
+    30/06: 7h 11h45-14h45 18h45-00h00
+    TXT;
+}


### PR DESCRIPTION
## Objectif
Éviter la saisie manuelle des prestations : importer en masse le relevé texte d'un freelance via une commande interactive.

## Contenu
- **`PrestationTextParser`** : parse une ligne `13/06: 9h15 11h45-15h 2V 18h45-2h` → `date`, `heures` décimales (`9h15` → 9,25), `horaires` (marqueurs `V` ignorés). Ignore les lignes vides et « TOTAL ». Signale les lignes illisibles.
- **`prestations:import`** (interactive) : sélection du **client** puis du **taux** (parmi ceux en base), collage du relevé, aperçu (tableau + total), confirmation, insertion en transaction. Adresse `PARIS`, année paramétrable.
- Options `--client`, `--taux`, `--year`, `--file`, `--adresse`, `--force` pour un usage scriptable (et les tests).
- Garde-fous : refus si une ligne est illisible (rien n'est créé) ou si le taux n'appartient pas au même utilisateur que le client.

## Tests (TDD)
- Parser : 6 tests (journée simple, plages multiples, `V` ignorés, ligne TOTAL, erreurs, **mois complet = 25 jours / 238 h**).
- Commande : 3 tests (import fichier, refus ligne illisible, refus taux d'un autre utilisateur).

**Suite complète : 57 tests verts.**

## Note
Le mois de juin compte **25 jours travaillés** (et non 24). Le relevé ajusté à 238 h (13/06→9h15, 16/06→9h, 30/06→7h) est fourni à part pour test en dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)