### PR TITLE
Colonne « Horaires » optionnelle sur les factures PDF

### DIFF
--- a/app/Http/Requests/ClientRequest.php
+++ b/app/Http/Requests/ClientRequest.php
@@ -26,7 +26,8 @@ class ClientRequest extends FormRequest
             'code_postal' => 'nullable|string|max:20',
             'ville'       => 'nullable|string|max:100',
             'pays'        => 'nullable|string|max:100',
-            'siren'       => 'nullable|regex:/^\d{9}(\d{5})?$/',
+            'siren'             => 'nullable|regex:/^\d{9}(\d{5})?$/',
+            'afficher_horaires' => 'sometimes|boolean',
         ];
     }
 

--- a/app/Http/Requests/ClientRequest.php
+++ b/app/Http/Requests/ClientRequest.php
@@ -21,11 +21,11 @@ class ClientRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'nom'         => 'required|string|max:255',
-            'adresse'     => 'nullable|string|max:255',
-            'code_postal' => 'nullable|string|max:20',
-            'ville'       => 'nullable|string|max:100',
-            'pays'        => 'nullable|string|max:100',
+            'nom'               => 'required|string|max:255',
+            'adresse'           => 'nullable|string|max:255',
+            'code_postal'       => 'nullable|string|max:20',
+            'ville'             => 'nullable|string|max:100',
+            'pays'              => 'nullable|string|max:100',
             'siren'             => 'nullable|regex:/^\d{9}(\d{5})?$/',
             'afficher_horaires' => 'sometimes|boolean',
         ];

--- a/app/Http/Resources/ClientResource.php
+++ b/app/Http/Resources/ClientResource.php
@@ -19,7 +19,8 @@ class ClientResource extends JsonResource
             'code_postal' => $this->code_postal,
             'ville'       => $this->ville,
             'pays'        => $this->pays,
-            'siren'       => $this->siren,
+            'siren'             => $this->siren,
+            'afficher_horaires' => (bool) $this->afficher_horaires,
             'created_at' => $this->created_at ? $this->created_at->format('d/m/Y H:i:s') : null,
             'updated_at' => $this->updated_at ? $this->updated_at->format('d/m/Y H:i:s') : null,
         ];

--- a/app/Http/Resources/ClientResource.php
+++ b/app/Http/Resources/ClientResource.php
@@ -13,16 +13,16 @@ class ClientResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'id'          => $this->id,
-            'nom'         => $this->nom,
-            'adresse'     => $this->adresse,
-            'code_postal' => $this->code_postal,
-            'ville'       => $this->ville,
-            'pays'        => $this->pays,
+            'id'                => $this->id,
+            'nom'               => $this->nom,
+            'adresse'           => $this->adresse,
+            'code_postal'       => $this->code_postal,
+            'ville'             => $this->ville,
+            'pays'              => $this->pays,
             'siren'             => $this->siren,
-            'afficher_horaires' => (bool) $this->afficher_horaires,
-            'created_at' => $this->created_at ? $this->created_at->format('d/m/Y H:i:s') : null,
-            'updated_at' => $this->updated_at ? $this->updated_at->format('d/m/Y H:i:s') : null,
+            'afficher_horaires' => $this->afficher_horaires,
+            'created_at'        => $this->created_at ? $this->created_at->format('d/m/Y H:i:s') : null,
+            'updated_at'        => $this->updated_at ? $this->updated_at->format('d/m/Y H:i:s') : null,
         ];
     }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -16,8 +16,16 @@ class Client extends Model
         'ville',
         'pays',
         'siren',
+        'afficher_horaires',
         'user_id',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'afficher_horaires' => 'boolean',
+        ];
+    }
 
     public function user()
     {

--- a/app/Services/ClientService.php
+++ b/app/Services/ClientService.php
@@ -18,7 +18,7 @@ class ClientService extends BaseService
     {
         return $this->handleExceptions(function () use ($data) {
             $data['user_id'] = Auth::id();
-            return Client::create($data);
+            return Client::create($data)->refresh();
         }, "Erreur lors de la création du client", "client");
     }
 

--- a/app/Services/FactureService.php
+++ b/app/Services/FactureService.php
@@ -114,10 +114,11 @@ class FactureService extends BaseService
             }
 
             $pdf = Pdf::loadView('invoices.pdf', [
-                'facture' => $facture,
-                'prestations' => $prestations,
-                'client' => $client,
-                'user' => $user,
+                'facture'          => $facture,
+                'prestations'      => $prestations,
+                'client'           => $client,
+                'user'             => $user,
+                'afficherHoraires' => (bool) $client->afficher_horaires,
             ]);
 
             return $pdf->output();

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -19,6 +19,7 @@ class ClientFactory extends Factory
             'ville'       => $this->faker->city(),
             'pays'        => 'France',
             'siren'       => (string) $this->faker->numberBetween(100000000, 999999999),
+            'afficher_horaires' => true,
             'user_id'     => User::factory(),
         ];
     }

--- a/database/migrations/2026_07_12_012022_add_afficher_horaires_to_clients_table.php
+++ b/database/migrations/2026_07_12_012022_add_afficher_horaires_to_clients_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clients', function (Blueprint $table) {
+            $table->boolean('afficher_horaires')->default(true)->after('siren');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clients', function (Blueprint $table) {
+            $table->dropColumn('afficher_horaires');
+        });
+    }
+};

--- a/docs/superpowers/plans/2026-07-12-horaires-optionnels-pdf.md
+++ b/docs/superpowers/plans/2026-07-12-horaires-optionnels-pdf.md
@@ -15,7 +15,7 @@
 - Nom de la variable de vue Blade : `$afficherHoraires`.
 - Défaut : `true`. Un client existant, ou créé sans le champ, affiche les horaires.
 - La donnée `horaires` de la prestation reste saisie et stockée : seul son affichage sur le PDF est conditionné.
-- Les tests PHP tournent dans le container : `docker compose exec app php artisan test`. Lancés depuis l'hôte, ils échouent sur `getaddrinfo for db failed`.
+- Les tests tournent en local, en SQLite en mémoire (cf. `phpunit.xml`) : `php artisan test --testsuite=Feature`. Ni Docker ni MySQL requis. (`php artisan test` sans argument échoue : `phpunit.xml` déclare une suite `Unit` alors que `tests/Unit/` n'existe pas — préexistant, hors périmètre.)
 - Commits en français, format `type: description`.
 
 ---
@@ -62,12 +62,12 @@ it('permet de masquer les horaires sur un client', function () {
 
 - [ ] **Step 2: Lancer le test et vérifier qu'il échoue**
 
-Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Run: `php artisan test --testsuite=Feature tests/Feature/ClientAfficherHorairesTest.php`
 Expected: FAIL — colonne `afficher_horaires` inconnue (`SQLSTATE ... Unknown column`).
 
 - [ ] **Step 3: Créer la migration**
 
-Run: `docker compose exec app php artisan make:migration add_afficher_horaires_to_clients_table --table=clients`
+Run: `php artisan make:migration add_afficher_horaires_to_clients_table --table=clients`
 
 Puis remplacer le corps du fichier généré par :
 
@@ -122,7 +122,7 @@ Dans `app/Models/Client.php`, ajouter `'afficher_horaires'` à `$fillable` (apr�
 
 - [ ] **Step 5: Lancer le test et vérifier qu'il passe**
 
-Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Run: `php artisan test --testsuite=Feature tests/Feature/ClientAfficherHorairesTest.php`
 Expected: PASS — 2 tests.
 
 - [ ] **Step 6: Commit**
@@ -181,7 +181,7 @@ it('persiste afficher_horaires à la mise à jour via l\'API', function () {
 
 - [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
 
-Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Run: `php artisan test --testsuite=Feature tests/Feature/ClientAfficherHorairesTest.php`
 Expected: FAIL sur les 2 nouveaux tests — le champ n'est pas validé donc jamais passé au modèle, `afficher_horaires` reste à `true`.
 
 - [ ] **Step 3: Autoriser le champ dans la validation**
@@ -206,7 +206,7 @@ Dans `app/Http/Resources/ClientResource.php`, ajouter la clé après `siren` :
 
 - [ ] **Step 5: Lancer les tests et vérifier qu'ils passent**
 
-Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Run: `php artisan test --testsuite=Feature tests/Feature/ClientAfficherHorairesTest.php`
 Expected: PASS — 4 tests.
 
 - [ ] **Step 6: Commit**
@@ -309,7 +309,7 @@ it('conserve les autres colonnes quand les horaires sont masqués', function () 
 
 - [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
 
-Run: `docker compose exec app php artisan test tests/Feature/FacturePdfHorairesTest.php`
+Run: `php artisan test --testsuite=Feature tests/Feature/FacturePdfHorairesTest.php`
 Expected: le test « affiche » PASSE déjà (la colonne est en dur), les tests « masque » et « conserve » ÉCHOUENT — le HTML contient toujours « Horaires » alors qu'on ne veut plus le voir.
 
 - [ ] **Step 3: Conditionner la colonne dans la vue**
@@ -363,12 +363,12 @@ Dans `app/Services/FactureService.php`, méthode `getPdf()`, compléter l'appel 
 
 - [ ] **Step 5: Lancer les tests et vérifier qu'ils passent**
 
-Run: `docker compose exec app php artisan test tests/Feature/FacturePdfHorairesTest.php`
+Run: `php artisan test --testsuite=Feature tests/Feature/FacturePdfHorairesTest.php`
 Expected: PASS — 3 tests.
 
 - [ ] **Step 6: Lancer toute la suite pour vérifier qu'aucun appelant de la vue n'a été oublié**
 
-Run: `docker compose exec app php artisan test`
+Run: `php artisan test --testsuite=Feature`
 Expected: PASS — toute la suite. Un échec ici signalerait un autre appel à `view('invoices.pdf')` sans `$afficherHoraires`.
 
 - [ ] **Step 7: Commit**
@@ -465,6 +465,6 @@ git commit -m "feat: case a cocher pour l'affichage des horaires dans la fiche c
 
 ## Vérification finale
 
-- [ ] `docker compose exec app php artisan test` — toute la suite passe.
+- [ ] `php artisan test --testsuite=Feature` — toute la suite passe.
 - [ ] Un client existant, jamais touché, produit un PDF identique à avant (colonne Horaires présente).
 - [ ] Un client avec la case décochée produit un PDF sans la colonne.

--- a/docs/superpowers/plans/2026-07-12-horaires-optionnels-pdf.md
+++ b/docs/superpowers/plans/2026-07-12-horaires-optionnels-pdf.md
@@ -1,0 +1,470 @@
+# Colonne « Horaires » optionnelle sur les factures PDF — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettre de masquer la colonne « Horaires » du tableau des prestations sur la facture PDF, client par client.
+
+**Architecture :** Un booléen `afficher_horaires` sur la table `clients` (défaut `true`, donc aucun changement pour les clients existants). `FactureService::getPdf()` le lit sur le client de la facture et le passe à la vue Blade sous le nom `$afficherHoraires` ; la vue conditionne l'en-tête et la cellule. Une case à cocher dans la fiche client pilote la valeur.
+
+**Tech Stack :** Laravel (API), Pest (`it()` + `RefreshDatabase`), Eloquent factories, barryvdh/laravel-dompdf, Vue 3 `<script setup>` + Pinia, Tailwind.
+
+## Global Constraints
+
+- Spec de référence : `docs/superpowers/specs/2026-07-12-facture-pdf-colonne-horaires-optionnelle-design.md`
+- Nom du champ en base et dans l'API : `afficher_horaires` (snake_case, français, cohérent avec `code_postal`).
+- Nom de la variable de vue Blade : `$afficherHoraires`.
+- Défaut : `true`. Un client existant, ou créé sans le champ, affiche les horaires.
+- La donnée `horaires` de la prestation reste saisie et stockée : seul son affichage sur le PDF est conditionné.
+- Les tests PHP tournent dans le container : `docker compose exec app php artisan test`. Lancés depuis l'hôte, ils échouent sur `getaddrinfo for db failed`.
+- Commits en français, format `type: description`.
+
+---
+
+### Task 1 : Le champ en base et sur le modèle
+
+**Files:**
+- Create: `database/migrations/<timestamp>_add_afficher_horaires_to_clients_table.php`
+- Modify: `app/Models/Client.php`
+- Test: `tests/Feature/ClientAfficherHorairesTest.php`
+
+**Interfaces:**
+- Consumes: rien (première tâche).
+- Produces: `Client::$afficher_horaires` — booléen casté, présent dans `$fillable`. Les tâches 2, 3 et 4 en dépendent.
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `tests/Feature/ClientAfficherHorairesTest.php` :
+
+```php
+<?php
+
+use App\Models\Client;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('affiche les horaires par défaut pour un client créé sans le champ', function () {
+    $client = Client::factory()->create(['user_id' => User::factory()]);
+
+    expect($client->fresh()->afficher_horaires)->toBeTrue();
+});
+
+it('permet de masquer les horaires sur un client', function () {
+    $client = Client::factory()->create([
+        'user_id'           => User::factory(),
+        'afficher_horaires' => false,
+    ]);
+
+    expect($client->fresh()->afficher_horaires)->toBeFalse();
+});
+```
+
+- [ ] **Step 2: Lancer le test et vérifier qu'il échoue**
+
+Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Expected: FAIL — colonne `afficher_horaires` inconnue (`SQLSTATE ... Unknown column`).
+
+- [ ] **Step 3: Créer la migration**
+
+Run: `docker compose exec app php artisan make:migration add_afficher_horaires_to_clients_table --table=clients`
+
+Puis remplacer le corps du fichier généré par :
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clients', function (Blueprint $table) {
+            $table->boolean('afficher_horaires')->default(true)->after('siren');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clients', function (Blueprint $table) {
+            $table->dropColumn('afficher_horaires');
+        });
+    }
+};
+```
+
+- [ ] **Step 4: Déclarer le champ sur le modèle**
+
+Dans `app/Models/Client.php`, ajouter `'afficher_horaires'` à `$fillable` (après `'siren'`) et ajouter la méthode de cast :
+
+```php
+    protected $fillable = [
+        'nom',
+        'adresse',
+        'code_postal',
+        'ville',
+        'pays',
+        'siren',
+        'afficher_horaires',
+        'user_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'afficher_horaires' => 'boolean',
+        ];
+    }
+```
+
+- [ ] **Step 5: Lancer le test et vérifier qu'il passe**
+
+Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add database/migrations app/Models/Client.php tests/Feature/ClientAfficherHorairesTest.php
+git commit -m "feat: ajoute le champ afficher_horaires sur le client"
+```
+
+---
+
+### Task 2 : Le champ traverse l'API
+
+**Files:**
+- Modify: `app/Http/Requests/ClientRequest.php`
+- Modify: `app/Http/Resources/ClientResource.php`
+- Test: `tests/Feature/ClientAfficherHorairesTest.php` (compléter le fichier de la tâche 1)
+
+**Interfaces:**
+- Consumes: `Client::$afficher_horaires` (tâche 1).
+- Produces: la clé `afficher_horaires` acceptée en entrée par `POST /api/clients` et `PUT /api/clients/{client}`, et renvoyée dans la réponse JSON. La tâche 4 (UI) en dépend.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Ajouter à la fin de `tests/Feature/ClientAfficherHorairesTest.php` :
+
+```php
+it('persiste afficher_horaires à la création via l\'API', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/clients', [
+        'nom'               => 'Client discret',
+        'afficher_horaires' => false,
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonPath('data.afficher_horaires', false);
+    expect(Client::where('nom', 'Client discret')->first()->afficher_horaires)->toBeFalse();
+});
+
+it('persiste afficher_horaires à la mise à jour via l\'API', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+
+    $response = $this->actingAs($user)->putJson("/api/clients/{$client->id}", [
+        'nom'               => $client->nom,
+        'afficher_horaires' => false,
+    ]);
+
+    $response->assertOk();
+    expect($client->fresh()->afficher_horaires)->toBeFalse();
+});
+```
+
+> Note : `assertCreated()` suppose que `ClientController::store` renvoie un 201. Si le contrôleur renvoie 200, adapter l'assertion à `assertOk()` — ne pas changer le contrôleur, cette tâche n'a pas à modifier son code de statut.
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Expected: FAIL sur les 2 nouveaux tests — le champ n'est pas validé donc jamais passé au modèle, `afficher_horaires` reste à `true`.
+
+- [ ] **Step 3: Autoriser le champ dans la validation**
+
+Dans `app/Http/Requests/ClientRequest.php`, ajouter la règle à la fin du tableau `rules()` :
+
+```php
+            'siren'             => 'nullable|regex:/^\d{9}(\d{5})?$/',
+            'afficher_horaires' => 'sometimes|boolean',
+```
+
+`sometimes` : si le front n'envoie pas la clé, la valeur en base n'est pas touchée (et vaut `true` par défaut à la création).
+
+- [ ] **Step 4: Exposer le champ dans la ressource**
+
+Dans `app/Http/Resources/ClientResource.php`, ajouter la clé après `siren` :
+
+```php
+            'siren'             => $this->siren,
+            'afficher_horaires' => (bool) $this->afficher_horaires,
+```
+
+- [ ] **Step 5: Lancer les tests et vérifier qu'ils passent**
+
+Run: `docker compose exec app php artisan test tests/Feature/ClientAfficherHorairesTest.php`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Http/Requests/ClientRequest.php app/Http/Resources/ClientResource.php tests/Feature/ClientAfficherHorairesTest.php
+git commit -m "feat: expose afficher_horaires dans l'API client"
+```
+
+---
+
+### Task 3 : Le PDF respecte le réglage
+
+C'est le cœur de la fonctionnalité. Le test porte sur le rendu de la vue Blade, en amont de dompdf : `Pdf::output()` renvoie du binaire compressé, inexploitable pour une assertion textuelle.
+
+**Files:**
+- Modify: `app/Services/FactureService.php` (dans `getPdf()`, l'appel `Pdf::loadView()` aux lignes 116-121)
+- Modify: `resources/views/invoices/pdf.blade.php` (l'en-tête ligne 154, la cellule ligne 165)
+- Test: `tests/Feature/FacturePdfHorairesTest.php`
+
+**Interfaces:**
+- Consumes: `Client::$afficher_horaires` (tâche 1).
+- Produces: la vue `invoices.pdf` exige désormais une variable `$afficherHoraires` (booléen) en plus de `$facture`, `$prestations`, `$client`, `$user`. Tout appelant de cette vue doit la fournir.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/Feature/FacturePdfHorairesTest.php` :
+
+```php
+<?php
+
+use App\Models\Client;
+use App\Models\Facture;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Rend la vue du PDF pour un client dont afficher_horaires vaut $afficherHoraires,
+ * et renvoie le HTML produit.
+ */
+function rendreVuePdf(bool $afficherHoraires): string
+{
+    $user   = User::factory()->create();
+    $client = Client::factory()->create([
+        'user_id'           => $user->id,
+        'afficher_horaires' => $afficherHoraires,
+    ]);
+    $taux    = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 25]);
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => $facture->id,
+        'horaires'        => '11h45-15h 18h45-2h',
+        'heures'          => 9.25,
+    ]);
+
+    return view('invoices.pdf', [
+        'facture'          => $facture,
+        'prestations'      => collect([$prestation->load('tauxHoraire')]),
+        'client'           => $client,
+        'user'             => $user,
+        'afficherHoraires' => $afficherHoraires,
+    ])->render();
+}
+
+it('affiche la colonne horaires quand le client l\'accepte', function () {
+    $html = rendreVuePdf(true);
+
+    expect($html)->toContain('Horaires');
+    expect($html)->toContain('11h45-15h 18h45-2h');
+});
+
+it('masque la colonne horaires quand le client la refuse', function () {
+    $html = rendreVuePdf(false);
+
+    expect($html)->not->toContain('Horaires');
+    expect($html)->not->toContain('11h45-15h 18h45-2h');
+});
+
+it('conserve les autres colonnes quand les horaires sont masqués', function () {
+    $html = rendreVuePdf(false);
+
+    // Les 5 colonnes restantes sont toujours là.
+    expect($html)->toContain('Réf.');
+    expect($html)->toContain('Date');
+    expect($html)->toContain('Qté');
+    expect($html)->toContain('PU HT');
+    expect($html)->toContain('Total HT');
+});
+```
+
+> Note : le rendu de la vue exige un `$user` avec `iban`, `name`, `prenom`, `adresse`, `ville`, `code_postal`, `siren`, `nom_societe` renseignés — vérifier que `UserFactory` les remplit. Si l'un manque, le compléter dans l'appel `User::factory()->create([...])` du helper plutôt que de modifier la factory.
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `docker compose exec app php artisan test tests/Feature/FacturePdfHorairesTest.php`
+Expected: le test « affiche » PASSE déjà (la colonne est en dur), les tests « masque » et « conserve » ÉCHOUENT — le HTML contient toujours « Horaires » alors qu'on ne veut plus le voir.
+
+- [ ] **Step 3: Conditionner la colonne dans la vue**
+
+Dans `resources/views/invoices/pdf.blade.php`, entourer l'en-tête (ligne 154) et la cellule (ligne 165) :
+
+```blade
+                <thead>
+                    <tr>
+                        <th>Réf.</th>
+                        <th>Date</th>
+                        @if ($afficherHoraires)
+                        <th>Horaires</th>
+                        @endif
+                        <th>Qté</th>
+                        <th>PU HT</th>
+                        <th>Total HT</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($prestations as $prestation)
+                    <tr>
+                        <td>{{ $prestation->id }}</td>
+                        <td>{{ \Carbon\Carbon::parse($prestation->date)->format('d/m/Y') }}</td>
+                        @if ($afficherHoraires)
+                        <td>{{ $prestation->horaires }}</td>
+                        @endif
+                        <td>{{ number_format($prestation->heures, 2, ',', ' ') }}</td>
+                        <td>{{ number_format($prestation->tauxHoraire->taux ?? 20, 2, ',', ' ') }} €</td>
+                        <td>{{ number_format($prestation->heures * ($prestation->tauxHoraire->taux ?? 20), 2, ',', ' ') }} €</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+```
+
+- [ ] **Step 4: Passer la variable depuis le service**
+
+Dans `app/Services/FactureService.php`, méthode `getPdf()`, compléter l'appel `Pdf::loadView()` (lignes 116-121) :
+
+```php
+            $pdf = Pdf::loadView('invoices.pdf', [
+                'facture'          => $facture,
+                'prestations'      => $prestations,
+                'client'           => $client,
+                'user'             => $user,
+                'afficherHoraires' => (bool) $client->afficher_horaires,
+            ]);
+```
+
+`$client` est déjà chargé ligne 88 (`$facture->prestations->first()->client`) : aucune requête supplémentaire.
+
+- [ ] **Step 5: Lancer les tests et vérifier qu'ils passent**
+
+Run: `docker compose exec app php artisan test tests/Feature/FacturePdfHorairesTest.php`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 6: Lancer toute la suite pour vérifier qu'aucun appelant de la vue n'a été oublié**
+
+Run: `docker compose exec app php artisan test`
+Expected: PASS — toute la suite. Un échec ici signalerait un autre appel à `view('invoices.pdf')` sans `$afficherHoraires`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/Services/FactureService.php resources/views/invoices/pdf.blade.php tests/Feature/FacturePdfHorairesTest.php
+git commit -m "feat: masque la colonne horaires du PDF selon le reglage du client"
+```
+
+---
+
+### Task 4 : La case à cocher dans la fiche client
+
+**Files:**
+- Modify: `resources/js/components/clients/ClientFormModal.vue`
+
+**Interfaces:**
+- Consumes: la clé `afficher_horaires` renvoyée et acceptée par l'API client (tâche 2).
+- Produces: rien — c'est la dernière tâche.
+
+Le formulaire envoie tout `clientData` au store (`addClient` / `updateClient`), donc ajouter la clé à l'objet réactif suffit à la transmettre. Pas de modification du store Pinia.
+
+- [ ] **Step 1: Ajouter la case au formulaire**
+
+Dans `resources/js/components/clients/ClientFormModal.vue`, insérer ce bloc dans le `<form>`, entre le champ SIREN (qui se termine ligne 106) et le bloc « Boutons » (ligne 108) :
+
+```html
+          <!-- Affichage des horaires sur la facture PDF -->
+          <div class="flex items-start gap-2 pt-2 border-t">
+            <input
+              type="checkbox"
+              id="afficher_horaires"
+              v-model="clientData.afficher_horaires"
+              class="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-2 focus:ring-indigo-500"
+            />
+            <label for="afficher_horaires" class="text-sm text-gray-700">
+              Afficher la colonne « Horaires » sur les factures PDF
+              <span class="block text-xs text-gray-500">
+                Décochez si ce client ne souhaite pas voir le détail des plages horaires.
+              </span>
+            </label>
+          </div>
+```
+
+- [ ] **Step 2: Déclarer le champ dans l'état du formulaire**
+
+Toujours dans le même fichier, ajouter `afficher_horaires: true` aux **deux** objets de `clientData` — la valeur initiale du `ref` (lignes 144-152) et les valeurs par défaut du `watchEffect` (lignes 158-166). Un nouveau client a donc la case cochée ; en édition, `{ ...props.client }` écrase la valeur avec celle venue de l'API.
+
+```js
+  const clientData = ref({
+    id: null,
+    nom: '',
+    adresse: '',
+    code_postal: '',
+    ville: '',
+    pays: '',
+    siren: '',
+    afficher_horaires: true,
+  });
+
+  watchEffect(() => {
+    clientData.value = props.client
+      ? { ...props.client }
+      : {
+          id: null,
+          nom: '',
+          adresse: '',
+          code_postal: '',
+          ville: '',
+          pays: '',
+          siren: '',
+          afficher_horaires: true,
+        };
+  });
+```
+
+- [ ] **Step 3: Vérifier le build du front**
+
+Run: `npm run build`
+Expected: build Vite réussi, sans erreur de compilation Vue.
+
+- [ ] **Step 4: Vérifier le comportement de bout en bout**
+
+Dans l'application : éditer un client, décocher la case, enregistrer, rouvrir la fiche — la case doit être restée décochée (l'API renvoie bien `false`). Puis générer le PDF d'une facture de ce client et vérifier que la colonne « Horaires » a disparu et que les cinq autres colonnes occupent la largeur. Faire le même contrôle sur un client resté coché : son PDF est inchangé.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/components/clients/ClientFormModal.vue
+git commit -m "feat: case a cocher pour l'affichage des horaires dans la fiche client"
+```
+
+---
+
+## Vérification finale
+
+- [ ] `docker compose exec app php artisan test` — toute la suite passe.
+- [ ] Un client existant, jamais touché, produit un PDF identique à avant (colonne Horaires présente).
+- [ ] Un client avec la case décochée produit un PDF sans la colonne.

--- a/docs/superpowers/specs/2026-07-12-facture-pdf-colonne-horaires-optionnelle-design.md
+++ b/docs/superpowers/specs/2026-07-12-facture-pdf-colonne-horaires-optionnelle-design.md
@@ -1,0 +1,80 @@
+# Colonne « Horaires » optionnelle sur les factures PDF
+
+Date : 2026-07-12
+
+## Problème
+
+Le tableau des prestations de la facture PDF affiche six colonnes : Réf., Date,
+Horaires, Qté, PU HT, Total HT. La colonne Horaires (les plages du type
+`11h45-15h 18h45-2h`) est codée en dur dans `resources/views/invoices/pdf.blade.php`.
+
+Certains clients ne veulent pas ce niveau de détail sur leurs factures. Il faut
+pouvoir masquer cette colonne pour eux, sans la masquer pour les autres et sans
+cesser de saisir l'information — les horaires restent utiles en interne et
+continuent d'être stockés sur la prestation.
+
+## Décisions
+
+**Le réglage vit sur le client**, pas sur la facture ni sur le téléchargement.
+Il est fixé une fois dans la fiche client et toutes ses factures suivent. Deux
+alternatives ont été écartées :
+
+- *Choix au moment de générer le PDF* — trop facile à oublier au mauvais moment,
+  et deux téléchargements de la même facture pourraient différer.
+- *Réglage figé sur la facture à sa création* — garantirait qu'un PDF donné ne
+  change jamais, mais coûte un champ supplémentaire sur chaque facture pour un
+  besoin d'archivage qui ne s'est pas manifesté.
+
+**Un booléen dédié, pas une structure de préférences.** Aucune autre colonne
+n'est candidate au masquage aujourd'hui. Une colonne JSON `colonnes_facture`
+serait payée immédiatement (validation, UI, code) pour un besoin hypothétique.
+Ajouter un second booléen le jour venu est une migration triviale.
+
+**Conséquence assumée** : modifier le réglage d'un client change aussi le PDF de
+ses factures déjà émises si on les retélécharge. Acceptable — la réédition d'un
+ancien PDF est un cas rare, et l'alternative coûtait plus cher que le risque.
+
+## Conception
+
+Le booléen `afficher_horaires` est ajouté à la table `clients` avec
+`default(true)`, de sorte que les clients existants conservent exactement le PDF
+qu'ils ont aujourd'hui. Le réglage traverse ensuite les couches habituelles du
+projet, sans nouveau pattern :
+
+| Couche | Fichier | Changement |
+|---|---|---|
+| Base | nouvelle migration | `boolean('afficher_horaires')->default(true)` |
+| Modèle | `app/Models/Client.php` | champ dans `$fillable`, cast `boolean` |
+| Validation | `app/Http/Requests/ClientRequest.php` | règle `sometimes\|boolean` |
+| API | `app/Http/Resources/ClientResource.php` | expose le champ au front |
+| Rendu | `app/Services/FactureService.php` | passe `afficher_horaires` du client à la vue |
+| PDF | `resources/views/invoices/pdf.blade.php` | `@if` autour du `<th>` et du `<td>` Horaires |
+| UI | `resources/js/components/clients/ClientFormModal.vue` | case à cocher, cochée par défaut |
+
+`FactureService::getPdf()` charge déjà le client pour l'en-tête du PDF : la
+valeur est donc disponible sans requête supplémentaire. Elle est passée à
+`Pdf::loadView()` sous le nom `$afficherHoraires`, comme une variable de vue à
+part entière plutôt que lue depuis `$client` dans la Blade, pour que la vue
+déclare explicitement ce dont elle dépend.
+
+Le tableau du PDF n'a pas de largeurs de colonnes fixes : les cinq colonnes
+restantes se répartissent l'espace automatiquement. Aucun ajustement CSS.
+
+## Tests
+
+`Pdf::output()` renvoie du binaire, difficile à inspecter. Les tests portent donc
+sur le rendu de la vue Blade, en amont de dompdf :
+
+- Rendu avec `afficher_horaires = true` → le HTML contient l'en-tête « Horaires »
+  et la valeur des horaires de la prestation.
+- Rendu avec `afficher_horaires = false` → ni l'un ni l'autre, et les lignes du
+  tableau comptent cinq cellules au lieu de six.
+- API client : le champ se persiste à la création et à la mise à jour ; un client
+  créé sans le champ vaut `true`.
+
+## Hors périmètre
+
+- L'e-mail de facture (`resources/views/emails/factures.blade.php`) n'affiche pas
+  les horaires — rien à y changer.
+- L'affichage des horaires dans l'application (liste des prestations) n'est pas
+  concerné : seul le PDF client l'est.

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,28 +1,28 @@
 {
-  "_ClientFormModal-B9jVyYlT.js": {
-    "file": "assets/ClientFormModal-B9jVyYlT.js",
+  "_ClientFormModal-kC33ghAL.js": {
+    "file": "assets/ClientFormModal-kC33ghAL.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_FactureFormModal-DcSAld0Q.js": {
-    "file": "assets/FactureFormModal-DcSAld0Q.js",
+  "_FactureFormModal-BHOkgSDQ.js": {
+    "file": "assets/FactureFormModal-BHOkgSDQ.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-Bc715Tmi.js"
+      "_prestations-fgN7mM5M.js"
     ]
   },
-  "_TauxHoraireFormModal-bCmwPyOD.js": {
-    "file": "assets/TauxHoraireFormModal-bCmwPyOD.js",
+  "_TauxHoraireFormModal-CN5Y5D5T.js": {
+    "file": "assets/TauxHoraireFormModal-CN5Y5D5T.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-Bc715Tmi.js": {
-    "file": "assets/prestations-Bc715Tmi.js",
+  "_prestations-fgN7mM5M.js": {
+    "file": "assets/prestations-fgN7mM5M.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -35,7 +35,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-ypAsml8t.css",
+    "file": "assets/app-wTpsCTyj.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -48,7 +48,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-DQQv7TGn.js",
+    "file": "assets/app-BkSPMG4M.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -66,52 +66,52 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-D1xxAO9P.js",
+    "file": "assets/Client-D_91LM0t.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_ClientFormModal-B9jVyYlT.js"
+      "_ClientFormModal-kC33ghAL.js"
     ],
     "css": [
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-DIoaYu0O.js",
+    "file": "assets/Dashboard-D_6nRPlc.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-DcSAld0Q.js",
-      "_prestations-Bc715Tmi.js"
+      "_FactureFormModal-BHOkgSDQ.js",
+      "_prestations-fgN7mM5M.js"
     ],
     "css": [
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-DgXfAk9J.js",
+    "file": "assets/Facture-Bh3sRqkC.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
-      "_FactureFormModal-DcSAld0Q.js",
+      "_FactureFormModal-BHOkgSDQ.js",
       "resources/js/app.js",
-      "_prestations-Bc715Tmi.js"
+      "_prestations-fgN7mM5M.js"
     ],
     "css": [
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-CLqbf3e1.js",
+    "file": "assets/Login-ctIZaKh3.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -119,11 +119,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-DH6Juk8V.js",
+    "file": "assets/NotFound-CTWc-ezJ.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -131,26 +131,26 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-DuIhdSXb.js",
+    "file": "assets/Prestation-CL8QgOBd.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-Bc715Tmi.js",
-      "_ClientFormModal-B9jVyYlT.js",
-      "_TauxHoraireFormModal-bCmwPyOD.js"
+      "_prestations-fgN7mM5M.js",
+      "_ClientFormModal-kC33ghAL.js",
+      "_TauxHoraireFormModal-CN5Y5D5T.js"
     ],
     "css": [
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-DR93clkZ.js",
+    "file": "assets/Profile-B-oNCq_8.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -159,11 +159,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-BFbckMUw.js",
+    "file": "assets/PwaStatus-Bqjmi5rG.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -172,23 +172,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-BABO9G4z.js",
+    "file": "assets/TauxHoraire-b8OQ-z-X.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-bCmwPyOD.js"
+      "_TauxHoraireFormModal-CN5Y5D5T.js"
     ],
     "css": [
-      "assets/app-ypAsml8t.css"
+      "assets/app-wTpsCTyj.css"
     ]
   }
 }

--- a/resources/js/components/clients/ClientFormModal.vue
+++ b/resources/js/components/clients/ClientFormModal.vue
@@ -104,7 +104,23 @@
               {{ errors.validationErrors.siren.join(', ') }}
             </p>
           </div>
-  
+
+          <!-- Affichage des horaires sur la facture PDF -->
+          <div class="flex items-start gap-2 pt-2 border-t">
+            <input
+              type="checkbox"
+              id="afficher_horaires"
+              v-model="clientData.afficher_horaires"
+              class="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-2 focus:ring-indigo-500"
+            />
+            <label for="afficher_horaires" class="text-sm text-gray-700">
+              Afficher la colonne « Horaires » sur les factures PDF
+              <span class="block text-xs text-gray-500">
+                Décochez si ce client ne souhaite pas voir le détail des plages horaires.
+              </span>
+            </label>
+          </div>
+
           <!-- Boutons -->
           <div class="flex justify-end space-x-3 mt-4">
             <button type="button" @click="closeModal" class="px-4 py-2 border border-gray-300 rounded hover:bg-gray-100 transition">
@@ -149,8 +165,9 @@
     ville: '',
     pays: '',
     siren: '',
+    afficher_horaires: true,
   });
-  
+
   // Initialiser les données avec les props si elles existent (édition) ou avec des valeurs par défaut
   watchEffect(() => {
     clientData.value = props.client
@@ -163,6 +180,7 @@
           ville: '',
           pays: '',
           siren: '',
+          afficher_horaires: true,
         };
   });
   

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -151,7 +151,9 @@
                     <tr>
                         <th>Réf.</th>
                         <th>Date</th>
+                        @if ($afficherHoraires)
                         <th>Horaires</th>
+                        @endif
                         <th>Qté</th>
                         <th>PU HT</th>
                         <th>Total HT</th>
@@ -162,7 +164,9 @@
                     <tr>
                         <td>{{ $prestation->id }}</td>
                         <td>{{ \Carbon\Carbon::parse($prestation->date)->format('d/m/Y') }}</td>
+                        @if ($afficherHoraires)
                         <td>{{ $prestation->horaires }}</td>
+                        @endif
                         <td>{{ number_format($prestation->heures, 2, ',', ' ') }}</td>
                         <td>{{ number_format($prestation->tauxHoraire->taux ?? 20, 2, ',', ' ') }} €</td>
                         <td>{{ number_format($prestation->heures * ($prestation->tauxHoraire->taux ?? 20), 2, ',', ' ') }} €</td>

--- a/tests/Feature/ClientAfficherHorairesTest.php
+++ b/tests/Feature/ClientAfficherHorairesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\Client;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('affiche les horaires par défaut pour un client créé sans le champ', function () {
+    $client = Client::factory()->create(['user_id' => User::factory()]);
+
+    expect($client->fresh()->afficher_horaires)->toBeTrue();
+});
+
+it('permet de masquer les horaires sur un client', function () {
+    $client = Client::factory()->create([
+        'user_id'           => User::factory(),
+        'afficher_horaires' => false,
+    ]);
+
+    expect($client->fresh()->afficher_horaires)->toBeFalse();
+});

--- a/tests/Feature/ClientAfficherHorairesTest.php
+++ b/tests/Feature/ClientAfficherHorairesTest.php
@@ -46,3 +46,19 @@ it('persiste afficher_horaires à la mise à jour via l\'API', function () {
     $response->assertOk();
     expect($client->fresh()->afficher_horaires)->toBeFalse();
 });
+
+it('conserve afficher_horaires à false quand la mise à jour ne l\'envoie pas', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create([
+        'user_id'           => $user->id,
+        'afficher_horaires' => false,
+    ]);
+
+    $response = $this->actingAs($user)->putJson("/api/clients/{$client->id}", [
+        'nom' => 'Nouveau nom du client',
+    ]);
+
+    $response->assertOk();
+    expect($client->fresh()->nom)->toBe('Nouveau nom du client');
+    expect($client->fresh()->afficher_horaires)->toBeFalse();
+});

--- a/tests/Feature/ClientAfficherHorairesTest.php
+++ b/tests/Feature/ClientAfficherHorairesTest.php
@@ -3,13 +3,27 @@
 use App\Models\Client;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class);
 
-it('affiche les horaires par défaut pour un client créé sans le champ', function () {
-    $client = Client::factory()->create(['user_id' => User::factory()]);
+it('affiche les horaires par défaut (contrainte de la base) pour un client créé sans le champ', function () {
+    // Insertion directe en base, sans passer par le modèle ni la factory (qui
+    // fixent désormais explicitement afficher_horaires) : on prouve ainsi que
+    // c'est bien le défaut de la colonne en base qui vaut true, pas une valeur
+    // fournie par le code applicatif.
+    $userId = User::factory()->create()->id;
 
-    expect($client->fresh()->afficher_horaires)->toBeTrue();
+    DB::table('clients')->insert([
+        'nom'        => 'Client sans horaires précisés',
+        'user_id'    => $userId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $client = Client::where('nom', 'Client sans horaires précisés')->first();
+
+    expect($client->afficher_horaires)->toBeTrue();
 });
 
 it('permet de masquer les horaires sur un client', function () {
@@ -19,6 +33,18 @@ it('permet de masquer les horaires sur un client', function () {
     ]);
 
     expect($client->fresh()->afficher_horaires)->toBeFalse();
+});
+
+it('renvoie afficher_horaires à true dans la réponse quand le champ n\'est pas envoyé à la création', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/clients', [
+        'nom' => 'Client par défaut',
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonPath('client.afficher_horaires', true);
+    expect(Client::where('nom', 'Client par défaut')->first()->afficher_horaires)->toBeTrue();
 });
 
 it('persiste afficher_horaires à la création via l\'API', function () {
@@ -59,6 +85,7 @@ it('conserve afficher_horaires à false quand la mise à jour ne l\'envoie pas',
     ]);
 
     $response->assertOk();
-    expect($client->fresh()->nom)->toBe('Nouveau nom du client');
-    expect($client->fresh()->afficher_horaires)->toBeFalse();
+    $clientActualise = $client->fresh();
+    expect($clientActualise->nom)->toBe('Nouveau nom du client');
+    expect($clientActualise->afficher_horaires)->toBeFalse();
 });

--- a/tests/Feature/ClientAfficherHorairesTest.php
+++ b/tests/Feature/ClientAfficherHorairesTest.php
@@ -20,3 +20,29 @@ it('permet de masquer les horaires sur un client', function () {
 
     expect($client->fresh()->afficher_horaires)->toBeFalse();
 });
+
+it('persiste afficher_horaires à la création via l\'API', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/clients', [
+        'nom'               => 'Client discret',
+        'afficher_horaires' => false,
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonPath('client.afficher_horaires', false);
+    expect(Client::where('nom', 'Client discret')->first()->afficher_horaires)->toBeFalse();
+});
+
+it('persiste afficher_horaires à la mise à jour via l\'API', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+
+    $response = $this->actingAs($user)->putJson("/api/clients/{$client->id}", [
+        'nom'               => $client->nom,
+        'afficher_horaires' => false,
+    ]);
+
+    $response->assertOk();
+    expect($client->fresh()->afficher_horaires)->toBeFalse();
+});

--- a/tests/Feature/FacturePdfHorairesTest.php
+++ b/tests/Feature/FacturePdfHorairesTest.php
@@ -6,6 +6,7 @@ use App\Models\Prestation;
 use App\Models\TauxHoraire;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 
 uses(RefreshDatabase::class);
 
@@ -126,17 +127,29 @@ function creerFactureAvecHoraires(bool $afficherHoraires): array
 it('télécharge un PDF valide pour une facture dont le client affiche les horaires', function () {
     ['user' => $user, 'facture' => $facture] = creerFactureAvecHoraires(true);
 
+    $donneesVue = [];
+    Event::listen('composing: invoices.pdf', function ($view) use (&$donneesVue) {
+        $donneesVue = $view->getData();
+    });
+
     $response = $this->actingAs($user)->getJson(route('factures.pdf', $facture));
 
     $response->assertOk();
     expect($response->streamedContent())->toStartWith('%PDF-');
+    expect($donneesVue['afficherHoraires'])->toBe(true);
 });
 
 it('télécharge un PDF valide pour une facture dont le client masque les horaires', function () {
     ['user' => $user, 'facture' => $facture] = creerFactureAvecHoraires(false);
 
+    $donneesVue = [];
+    Event::listen('composing: invoices.pdf', function ($view) use (&$donneesVue) {
+        $donneesVue = $view->getData();
+    });
+
     $response = $this->actingAs($user)->getJson(route('factures.pdf', $facture));
 
     $response->assertOk();
     expect($response->streamedContent())->toStartWith('%PDF-');
+    expect($donneesVue['afficherHoraires'])->toBe(false);
 });

--- a/tests/Feature/FacturePdfHorairesTest.php
+++ b/tests/Feature/FacturePdfHorairesTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Facture;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Rend la vue du PDF pour un client dont afficher_horaires vaut $afficherHoraires,
+ * et renvoie le HTML produit.
+ */
+function rendreVuePdf(bool $afficherHoraires): string
+{
+    $user   = User::factory()->create([
+        'iban'        => 'FR7630006000011234567890189',
+        'name'        => 'Dupont',
+        'prenom'      => 'Jean',
+        'adresse'     => '1 rue de Paris',
+        'ville'       => 'Paris',
+        'code_postal' => '75001',
+        'siren'       => '123456789',
+        'nom_societe' => 'Jean Dupont Freelance',
+    ]);
+    $client = Client::factory()->create([
+        'user_id'           => $user->id,
+        'afficher_horaires' => $afficherHoraires,
+    ]);
+    $taux    = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 25]);
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => $facture->id,
+        'horaires'        => '11h45-15h 18h45-2h',
+        'heures'          => 9.25,
+    ]);
+
+    return view('invoices.pdf', [
+        'facture'          => $facture,
+        'prestations'      => collect([$prestation->load('tauxHoraire')]),
+        'client'           => $client,
+        'user'             => $user,
+        'afficherHoraires' => $afficherHoraires,
+    ])->render();
+}
+
+it('affiche la colonne horaires quand le client l\'accepte', function () {
+    $html = rendreVuePdf(true);
+
+    expect($html)->toContain('Horaires');
+    expect($html)->toContain('11h45-15h 18h45-2h');
+});
+
+it('masque la colonne horaires quand le client la refuse', function () {
+    $html = rendreVuePdf(false);
+
+    expect($html)->not->toContain('Horaires');
+    expect($html)->not->toContain('11h45-15h 18h45-2h');
+});
+
+it('conserve les autres colonnes quand les horaires sont masqués', function () {
+    $html = rendreVuePdf(false);
+
+    // Les 5 colonnes restantes sont toujours là.
+    expect($html)->toContain('Réf.');
+    expect($html)->toContain('Date');
+    expect($html)->toContain('Qté');
+    expect($html)->toContain('PU HT');
+    expect($html)->toContain('Total HT');
+});

--- a/tests/Feature/FacturePdfHorairesTest.php
+++ b/tests/Feature/FacturePdfHorairesTest.php
@@ -73,4 +73,70 @@ it('conserve les autres colonnes quand les horaires sont masqués', function () 
     expect($html)->toContain('Qté');
     expect($html)->toContain('PU HT');
     expect($html)->toContain('Total HT');
+
+    // Et les lignes du tableau des prestations comptent bien 5 cellules, pas 6.
+    // On isole le <tbody> : c'est le seul de tout le document (le tableau
+    // d'en-tête N° facture / date / lieu n'utilise que des <tr> bruts).
+    preg_match('/<tbody>(.*?)<\/tbody>/s', $html, $tbodyMatch);
+    expect($tbodyMatch)->toHaveCount(2);
+
+    preg_match('/<tr>(.*?)<\/tr>/s', $tbodyMatch[1], $rowMatch);
+    expect($rowMatch)->toHaveCount(2);
+
+    $nbCellules = substr_count($rowMatch[1], '<td>');
+    expect($nbCellules)->toBe(5);
+});
+
+/**
+ * Crée un jeu de données complet (utilisateur au profil complet, client,
+ * taux horaire, facture et prestation) prêt pour appeler le vrai endpoint
+ * GET /api/factures/{id}/pdf.
+ */
+function creerFactureAvecHoraires(bool $afficherHoraires): array
+{
+    $user = User::factory()->create([
+        'iban'        => 'FR7630006000011234567890189',
+        'name'        => 'Dupont',
+        'prenom'      => 'Jean',
+        'adresse'     => '1 rue de Paris',
+        'ville'       => 'Paris',
+        'code_postal' => '75001',
+        'siren'       => '123456789',
+        'nom_societe' => 'Jean Dupont Freelance',
+    ]);
+    $client = Client::factory()->create([
+        'user_id'           => $user->id,
+        'afficher_horaires' => $afficherHoraires,
+    ]);
+    $taux    = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 25]);
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+
+    Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => $facture->id,
+        'horaires'        => '11h45-15h 18h45-2h',
+        'heures'          => 9.25,
+    ]);
+
+    return ['user' => $user, 'facture' => $facture];
+}
+
+it('télécharge un PDF valide pour une facture dont le client affiche les horaires', function () {
+    ['user' => $user, 'facture' => $facture] = creerFactureAvecHoraires(true);
+
+    $response = $this->actingAs($user)->getJson(route('factures.pdf', $facture));
+
+    $response->assertOk();
+    expect($response->streamedContent())->toStartWith('%PDF-');
+});
+
+it('télécharge un PDF valide pour une facture dont le client masque les horaires', function () {
+    ['user' => $user, 'facture' => $facture] = creerFactureAvecHoraires(false);
+
+    $response = $this->actingAs($user)->getJson(route('factures.pdf', $facture));
+
+    $response->assertOk();
+    expect($response->streamedContent())->toStartWith('%PDF-');
 });


### PR DESCRIPTION
Certains clients ne veulent pas voir le détail des plages horaires sur leurs factures. Cette PR ajoute un booléen `afficher_horaires` sur le client (défaut `true`) qui conditionne l'affichage de la colonne « Horaires » du tableau des prestations dans le PDF.

Le réglage vit sur le **client**, pas sur la facture : il se fixe une fois dans la fiche client et toutes ses factures suivent. Conséquence assumée : retélécharger une facture déjà émise reflète le réglage courant du client.

## Ce que ça change

| Couche | Changement |
|---|---|
| Base | `boolean afficher_horaires` sur `clients`, `default(true)` — les clients existants sont inchangés |
| API | Validé (`sometimes\|boolean`) et exposé dans `ClientResource` |
| PDF | `@if` sur l'en-tête et la cellule ; `FactureService::getPdf()` passe `$afficherHoraires` à la vue |
| UI | Case à cocher dans la fiche client |

La donnée `horaires` reste saisie et stockée : seul son **affichage sur le PDF** est conditionné.

## Vérifications

- **Aucune régression sur les factures existantes** : le PDF binaire d'un client non touché est identique à l'octet près à celui d'avant la branche (hors l'ID aléatoire du trailer).
- **Sécurité** : `PUT /api/clients/{client}` par un tiers renvoie bien 403, le champ n'ouvre aucune nouvelle surface d'exposition.
- **Migration** sûre sur une base contenant déjà des clients (`TINYINT(1) NOT NULL DEFAULT 1`).
- Suite : **68 tests, 214 assertions**. Build Vite OK.

## Un bug trouvé en revue

`ClientService::create()` ne relisait pas la ligne après l'INSERT : un client créé sans envoyer `afficher_horaires` se voyait répondre `false` par l'API alors que la base contenait `true`. Inatteignable depuis la SPA (qui envoie toujours la clé), mais tout autre consommateur aurait fait perdre au client sa colonne Horaires sans qu'il l'ait demandé. Corrigé par un `->refresh()`, et verrouillé par un test.

Deux trous de test ont aussi été comblés : la route `GET /api/factures/{id}/pdf` n'avait aucun test de succès, et rien ne vérifiait que la valeur du client atteignait réellement la vue — on pouvait mettre `'afficherHoraires' => true` en dur dans le service sans qu'un seul test ne tombe.

## Suite prévue

Un piège latent a été repéré hors périmètre : le `ClientFormModal` de `PrestationListItem.vue` édite une copie périmée du client. Son bouton n'est branché nulle part (code mort), mais il faudra le faire pointer sur le store `clients` avant de l'activer un jour.

Spec et plan : `docs/superpowers/specs/2026-07-12-facture-pdf-colonne-horaires-optionnelle-design.md`, `docs/superpowers/plans/2026-07-12-horaires-optionnels-pdf.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj