### PR TITLE
Supprime le modal client mort de la liste des prestations

### DIFF
--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,28 +1,28 @@
 {
-  "_ClientFormModal-kC33ghAL.js": {
-    "file": "assets/ClientFormModal-kC33ghAL.js",
+  "_ClientFormModal-DzOamBmx.js": {
+    "file": "assets/ClientFormModal-DzOamBmx.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_FactureFormModal-BHOkgSDQ.js": {
-    "file": "assets/FactureFormModal-BHOkgSDQ.js",
+  "_FactureFormModal-DM_2-ZmD.js": {
+    "file": "assets/FactureFormModal-DM_2-ZmD.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-fgN7mM5M.js"
+      "_prestations-DvXuxl5t.js"
     ]
   },
-  "_TauxHoraireFormModal-CN5Y5D5T.js": {
-    "file": "assets/TauxHoraireFormModal-CN5Y5D5T.js",
+  "_TauxHoraireFormModal-LCvb2Uvh.js": {
+    "file": "assets/TauxHoraireFormModal-LCvb2Uvh.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-fgN7mM5M.js": {
-    "file": "assets/prestations-fgN7mM5M.js",
+  "_prestations-DvXuxl5t.js": {
+    "file": "assets/prestations-DvXuxl5t.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -35,7 +35,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-wTpsCTyj.css",
+    "file": "assets/app-C2Kpw-il.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -48,7 +48,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-BkSPMG4M.js",
+    "file": "assets/app-HmLDUmDv.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -66,52 +66,52 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-D_91LM0t.js",
+    "file": "assets/Client-BByHK5n5.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_ClientFormModal-kC33ghAL.js"
+      "_ClientFormModal-DzOamBmx.js"
     ],
     "css": [
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-D_6nRPlc.js",
+    "file": "assets/Dashboard-Cyl49xNQ.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-BHOkgSDQ.js",
-      "_prestations-fgN7mM5M.js"
+      "_FactureFormModal-DM_2-ZmD.js",
+      "_prestations-DvXuxl5t.js"
     ],
     "css": [
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-Bh3sRqkC.js",
+    "file": "assets/Facture-Ti9kKosR.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
-      "_FactureFormModal-BHOkgSDQ.js",
+      "_FactureFormModal-DM_2-ZmD.js",
       "resources/js/app.js",
-      "_prestations-fgN7mM5M.js"
+      "_prestations-DvXuxl5t.js"
     ],
     "css": [
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-ctIZaKh3.js",
+    "file": "assets/Login-Co-t4MXu.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -119,11 +119,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-CTWc-ezJ.js",
+    "file": "assets/NotFound-BaaVp5hJ.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -131,26 +131,26 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-CL8QgOBd.js",
+    "file": "assets/Prestation-BB9441kc.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-fgN7mM5M.js",
-      "_ClientFormModal-kC33ghAL.js",
-      "_TauxHoraireFormModal-CN5Y5D5T.js"
+      "_prestations-DvXuxl5t.js",
+      "_ClientFormModal-DzOamBmx.js",
+      "_TauxHoraireFormModal-LCvb2Uvh.js"
     ],
     "css": [
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-B-oNCq_8.js",
+    "file": "assets/Profile-AJ94-J8p.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -159,11 +159,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-Bqjmi5rG.js",
+    "file": "assets/PwaStatus-Bc4-W2Yf.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -172,23 +172,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-b8OQ-z-X.js",
+    "file": "assets/TauxHoraire-BGfc1Poq.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-CN5Y5D5T.js"
+      "_TauxHoraireFormModal-LCvb2Uvh.js"
     ],
     "css": [
-      "assets/app-wTpsCTyj.css"
+      "assets/app-C2Kpw-il.css"
     ]
   }
 }

--- a/resources/js/components/prestations/PrestationListItem.vue
+++ b/resources/js/components/prestations/PrestationListItem.vue
@@ -76,13 +76,11 @@
   <!-- Modals -->
   <PrestationFormModal v-if="showFormModal" :prestation="prestation" @close="closeFormModal" />
   <PrestationDeleteModal v-if="showDeleteModal" :prestation="prestation" @close="closeDeleteModal" />
-  <ClientFormModal v-if="showClientModal" :client="prestation.client" @close="closeClientModal" />
 </template>
 
 <script setup>
 import { ref } from "vue";
 import { PrestationFormModal, PrestationDeleteModal } from "@/components/prestations/";
-import { ClientFormModal } from "@/components/clients/";
 import { formatDate } from "@/utils";
 
 const props = defineProps({
@@ -96,7 +94,6 @@ const emit = defineEmits(["close"]);
 
 const showFormModal = ref(false);
 const showDeleteModal = ref(false);
-const showClientModal = ref(false);
 
 function openFormModal() {
   showFormModal.value = true;
@@ -112,13 +109,5 @@ function openDeleteModal() {
 
 function closeDeleteModal() {
   showDeleteModal.value = false;
-}
-
-function openClientModal() {
-  showClientModal.value = true;
-}
-
-function closeClientModal() {
-  showClientModal.value = false;
 }
 </script>


### PR DESCRIPTION
Nettoyage repéré lors de la revue finale de la PR #19, laissé hors périmètre à l'époque.

## Le problème

`PrestationListItem.vue` montait un `ClientFormModal` sur `:client="prestation.client"` — une copie du client issue du **store prestations**, que `updateClient()` ne rafraîchit jamais (il ne met à jour que `clients.value`).

Ce code était **inerte** : `openClientModal()` n'était câblé à aucun bouton, donc `showClientModal` ne pouvait jamais passer à `true`. Mais il constituait un piège pour le jour où quelqu'un aurait branché ce bouton : décocher `afficher_horaires` depuis la liste des prestations, puis rouvrir la même fiche, aurait réaffiché la case cochée (valeur périmée en mémoire) et le prochain enregistrement aurait **silencieusement annulé le réglage** — la facture repartant avec les horaires que le client avait refusés.

La péremption existait déjà pour `nom` et `adresse`, mais elle y est *visible* (l'ancienne valeur s'affiche). Sur une case à cocher, elle est indiscernable d'un choix délibéré.

## Ce que fait cette PR

Suppression des cinq fragments morts de `PrestationListItem.vue` : la balise `<ClientFormModal>`, son import, le `ref showClientModal`, et les fonctions `openClientModal` / `closeClientModal`.

Les clients continuent de s'éditer depuis leur page dédiée (`ClientListItem`), où le modal pointe correctement sur le store `clients`. Les deux autres usages de `ClientFormModal` (création depuis `Client.vue` et depuis `PrestationFormModal`) sont sains et intacts.

## Vérifications

- `npm run build` passe — il aurait attrapé une référence ou un import oublié.
- Suite : **68 tests, 214 assertions**, verte.
- Aucun changement de comportement possible : le code retiré ne s'exécutait jamais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj