### PR TITLE
Refonte de l'onglet Factures : liste dense et prestations dépliables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+
+# Maquettes de brainstorming (locales)
+.superpowers/

--- a/docs/superpowers/plans/2026-07-12-refonte-onglet-factures.md
+++ b/docs/superpowers/plans/2026-07-12-refonte-onglet-factures.md
@@ -1,0 +1,700 @@
+# Refonte de l'onglet Factures — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remplacer la grille de cartes de l'onglet Factures par une liste dense en lignes, dont les prestations se déplient, avec des filtres statut / client / mois.
+
+**Architecture :** Le store des factures gagne des filtres côté client (même pattern que le store des prestations). `FactureListItem` devient une ligne dépliable au lieu d'une carte, et délègue le détail à un nouveau `FacturePrestationsTable`. `FacturesList` orchestre les filtres et les quatre états d'affichage. Aucun changement backend.
+
+**Tech Stack :** Vue 3 (`<script setup>`, Composition API), Pinia, Tailwind CSS v4, Vite.
+
+## Global Constraints
+
+- Spec de référence : `docs/superpowers/specs/2026-07-12-refonte-onglet-factures-design.md`
+- **Aucune modification backend** : pas de migration, pas de contrôleur, pas de ressource API, pas de route. Si une tâche semble l'exiger, c'est une erreur — s'arrêter et le signaler.
+- **Tri : `invoice.id` décroissant.** NE PAS trier sur `created_at` : `FactureResource` le renvoie au format `d/m/Y H:i:s`, que JavaScript ne sait ni trier ni parser nativement. Les identifiants croissent avec le temps et donnent le même ordre.
+- **Filtre par mois : comparaison de préfixe.** `PrestationResource` renvoie `date` au format `Y-m-d`, donc `prestation.date.startsWith(month_year)` suffit. Aucun parsing de date.
+- `invoice.prestations[0]` doit toujours être accédé avec `?.` — une facture sans prestation ferait planter le rendu de toute la liste.
+- Les horaires s'affichent dans cette vue même si le client a `afficher_horaires = false` : ce réglage ne concerne que le PDF envoyé au client.
+- Statuts possibles : `en_attente_envoi`, `en_attente_paiement`, `payé`.
+- **Pas de tests front sur ce projet.** La vérification de chaque tâche est : `npm run build` (attrape les erreurs de compilation Vue) + un contrôle visuel dans l'app sur http://localhost:8080. La suite `php artisan test --testsuite=Feature` doit rester verte (68 tests) — aucune tâche ne touche au backend.
+- Vue 3 `<script setup>`, Tailwind, classes globales existantes (`.btn-action`, `.filter-input`, `.btn-secondary`) — suivre le style des composants voisins.
+- Commits en français, format `type: description`.
+
+---
+
+### Task 1 : Les filtres dans le store
+
+**Files:**
+- Modify: `resources/js/stores/factures.js`
+
+**Interfaces:**
+- Consumes: rien (première tâche).
+- Produces: le store expose en plus `activeFilters` (`{ statut, client_id, month_year }`), `updateFilters(filters)`, `isAnyFilterActive` (computed booléen), et `filteredInvoices` (ref, triée par `id` décroissant). Les tâches 2, 4 et 5 en dépendent.
+
+Le store des prestations (`resources/js/stores/prestations.js`, lignes 12-43) fait déjà exactement ça. On calque, en adaptant les critères.
+
+- [ ] **Step 1: Ajouter les filtres au store**
+
+Dans `resources/js/stores/factures.js`, remplacer la ligne d'import de Vue :
+
+```js
+import { ref, computed, watch } from 'vue';
+```
+
+Puis, juste après `const loading = ref({});`, ajouter :
+
+```js
+  // Filtres de la liste des factures (appliqués côté client)
+  const activeFilters = ref({
+    statut: '',
+    client_id: '',
+    month_year: '',
+  });
+
+  function updateFilters(filters) {
+    activeFilters.value = filters;
+  }
+
+  const isAnyFilterActive = computed(() => {
+    return Object.values(activeFilters.value).some(value => value !== "");
+  });
+
+  // Factures filtrées, les plus récentes en tête.
+  // Le tri se fait sur l'id : created_at arrive au format d/m/Y H:i:s,
+  // que JavaScript ne sait pas trier.
+  const filteredInvoices = ref([]);
+  watch([invoices, activeFilters], () => {
+    filteredInvoices.value = invoices.value
+      .filter(invoice => {
+        const { statut, client_id, month_year } = activeFilters.value;
+
+        if (statut && invoice.statut !== statut) return false;
+
+        if (client_id && invoice.prestations?.[0]?.client_id !== client_id) return false;
+
+        // La facture est retenue si au moins une de ses prestations
+        // tombe dans le mois demandé. prestation.date est au format Y-m-d.
+        if (month_year && !invoice.prestations?.some(p => p.date?.startsWith(month_year))) return false;
+
+        return true;
+      })
+      .sort((a, b) => b.id - a.id);
+  }, { deep: true, immediate: true });
+```
+
+- [ ] **Step 2: Exposer les nouvelles clés**
+
+Toujours dans `resources/js/stores/factures.js`, compléter l'objet retourné en fin de store :
+
+```js
+  return {
+    invoices,
+    filteredInvoices,
+    activeFilters,
+    updateFilters,
+    isAnyFilterActive,
+    errors,
+    loading,
+    fetchInvoices,
+    addInvoice,
+    deleteInvoice,
+    clearErrors,
+    getInvoicePdf,
+    paid,
+  };
+```
+
+- [ ] **Step 3: Vérifier le build**
+
+Run: `npm run build`
+Expected: build Vite réussi, aucune erreur.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/stores/factures.js
+git commit -m "feat: ajoute les filtres et le tri au store des factures"
+```
+
+---
+
+### Task 2 : Le formatage des nombres, et le tableau des prestations dépliées
+
+Composant isolé : il ne connaît que sa liste de prestations et ne sait rien de la ligne qui le contient.
+
+**Files:**
+- Modify: `resources/js/utils.js`
+- Create: `resources/js/components/factures/FacturePrestationsTable.vue`
+- Modify: `resources/js/components/factures/index.js`
+
+**Interfaces:**
+- Consumes: rien du store.
+- Produces:
+  - `formatNombre(valeur)` et `formatEuros(valeur)`, exportés depuis `@/utils` — la tâche 4 les importe aussi. Ne PAS les redéfinir dans les composants.
+  - `<FacturePrestationsTable :prestations="invoice.prestations" />`. Prop unique `prestations` (Array, requis). La tâche 4 l'utilise.
+
+- [ ] **Step 1: Ajouter les formateurs aux utilitaires**
+
+`resources/js/utils.js` porte déjà `formatDate`. Y ajouter, à la fin du fichier, les deux formateurs partagés — ils servent dans le tableau (tâche 2) ET dans la ligne (tâche 4), donc ils n'ont pas leur place dans un composant :
+
+```js
+export function formatNombre(valeur) {
+  return new Intl.NumberFormat('fr-FR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(valeur);
+}
+
+export function formatEuros(valeur) {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(valeur);
+}
+```
+
+- [ ] **Step 2: Créer le composant**
+
+Créer `resources/js/components/factures/FacturePrestationsTable.vue` :
+
+```vue
+<template>
+  <div class="overflow-x-auto rounded-lg bg-gray-950/60 ring-1 ring-gray-700">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="text-left text-xs uppercase tracking-wide text-gray-400">
+          <th class="px-3 py-2 font-medium">Date</th>
+          <th class="px-3 py-2 font-medium">Horaires</th>
+          <th class="px-3 py-2 font-medium text-right">Heures</th>
+          <th class="px-3 py-2 font-medium text-right">Taux</th>
+          <th class="px-3 py-2 font-medium text-right">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="prestation in prestations"
+          :key="prestation.id"
+          class="border-t border-gray-800 text-gray-200"
+        >
+          <td class="px-3 py-2 whitespace-nowrap tabular-nums">{{ formatDate(prestation.date) }}</td>
+          <td class="px-3 py-2 text-gray-400">{{ prestation.horaires || '—' }}</td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(prestation.heures) }}</td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(prestation.taux_horaire.taux) }}</td>
+          <td class="px-3 py-2 text-right tabular-nums font-medium text-white">
+            {{ formatEuros(prestation.heures * prestation.taux_horaire.taux) }}
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr class="border-t border-gray-700 font-semibold text-white">
+          <td class="px-3 py-2" colspan="2">
+            {{ prestations.length }} prestation{{ prestations.length > 1 ? 's' : '' }}
+          </td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(totalHeures) }}</td>
+          <td class="px-3 py-2"></td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(totalMontant) }}</td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { formatDate, formatNombre, formatEuros } from '@/utils';
+
+const props = defineProps({
+  prestations: {
+    type: Array,
+    required: true,
+  },
+});
+
+const totalHeures = computed(() =>
+  props.prestations.reduce((acc, p) => acc + parseFloat(p.heures), 0)
+);
+
+const totalMontant = computed(() =>
+  props.prestations.reduce((acc, p) => acc + parseFloat(p.heures) * parseFloat(p.taux_horaire.taux), 0)
+);
+</script>
+```
+
+- [ ] **Step 3: Exporter le composant**
+
+Dans `resources/js/components/factures/index.js`, ajouter la ligne d'export en suivant le format des lignes existantes du fichier (lire le fichier d'abord pour reproduire son style exact) :
+
+```js
+export { default as FacturePrestationsTable } from './FacturePrestationsTable.vue';
+```
+
+- [ ] **Step 4: Vérifier le build**
+
+Run: `npm run build`
+Expected: build Vite réussi.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/utils.js resources/js/components/factures/FacturePrestationsTable.vue resources/js/components/factures/index.js
+git commit -m "feat: ajoute le tableau des prestations d'une facture"
+```
+
+---
+
+### Task 3 : Les filtres de la liste
+
+**Files:**
+- Create: `resources/js/components/factures/FactureFilters.vue`
+- Modify: `resources/js/components/factures/index.js`
+
+**Interfaces:**
+- Consumes: du store des factures (tâche 1) — `activeFilters`, `updateFilters`, `isAnyFilterActive`.
+- Produces: `<FactureFilters />`, sans prop. La tâche 5 le monte.
+
+Ce composant calque `resources/js/components/prestations/PrestationsFilters.vue` : les filtres vivent dans le store, un `watch` profond les propage, le bouton de réinitialisation n'apparaît que si un filtre est actif.
+
+- [ ] **Step 1: Créer le composant**
+
+Créer `resources/js/components/factures/FactureFilters.vue` :
+
+```vue
+<template>
+  <div class="bg-gray-800 p-4 rounded-lg shadow-lg flex flex-col sm:flex-row gap-4 sm:items-end">
+    <div class="flex-1">
+      <label for="filtre-statut" class="text-sm text-gray-300 font-semibold">Statut :</label>
+      <select id="filtre-statut" v-model="activeFilters.statut" class="filter-input">
+        <option value="">Tous les statuts</option>
+        <option value="en_attente_envoi">En attente d'envoi</option>
+        <option value="en_attente_paiement">En attente de paiement</option>
+        <option value="payé">Payé</option>
+      </select>
+    </div>
+
+    <div class="flex-1">
+      <label for="filtre-client" class="text-sm text-gray-300 font-semibold">Client :</label>
+      <select id="filtre-client" v-model="activeFilters.client_id" class="filter-input">
+        <option value="">Tous les clients</option>
+        <option v-for="client in clients" :key="client.id" :value="client.id">
+          {{ client.nom }}
+        </option>
+      </select>
+    </div>
+
+    <div class="flex-1">
+      <label for="filtre-mois" class="text-sm text-gray-300 font-semibold">Mois des prestations :</label>
+      <input id="filtre-mois" type="month" v-model="activeFilters.month_year" class="filter-input" />
+    </div>
+
+    <button v-if="isAnyFilterActive" @click="resetFilters" class="btn-secondary whitespace-nowrap">
+      Réinitialiser
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, watch } from 'vue';
+import { useInvoicesStore } from '@/stores/factures';
+import { useClientsStore } from '@/stores/clients';
+import { storeToRefs } from 'pinia';
+
+const invoicesStore = useInvoicesStore();
+const clientsStore = useClientsStore();
+
+const { activeFilters, isAnyFilterActive } = storeToRefs(invoicesStore);
+const { updateFilters } = invoicesStore;
+
+const { fetchClients } = clientsStore;
+const { clients } = storeToRefs(clientsStore);
+
+onMounted(() => {
+  fetchClients();
+});
+
+watch(activeFilters, (newFilters) => {
+  updateFilters(newFilters);
+}, { deep: true });
+
+const resetFilters = () => {
+  updateFilters({
+    statut: '',
+    client_id: '',
+    month_year: '',
+  });
+};
+</script>
+```
+
+- [ ] **Step 2: Exporter le composant**
+
+Dans `resources/js/components/factures/index.js`, ajouter (en suivant le style du fichier) :
+
+```js
+export { default as FactureFilters } from './FactureFilters.vue';
+```
+
+- [ ] **Step 3: Vérifier le build**
+
+Run: `npm run build`
+Expected: build Vite réussi.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/components/factures/FactureFilters.vue resources/js/components/factures/index.js
+git commit -m "feat: ajoute les filtres de la liste des factures"
+```
+
+---
+
+### Task 4 : La ligne de facture dépliable
+
+Le cœur de la refonte. `FactureListItem.vue` cesse d'être une carte : il devient une ligne, et son détail est délégué au tableau de la tâche 2.
+
+**Files:**
+- Modify (récriture complète) : `resources/js/components/factures/FactureListItem.vue`
+
+**Interfaces:**
+- Consumes: `<FacturePrestationsTable :prestations="..." />` et les formateurs `formatNombre` / `formatEuros` de `@/utils` (tâche 2). Les importer, ne pas les redéfinir ici.
+- Produces: `<FactureListItem :invoice="invoice" />`. Prop unique `invoice` (Object, requis). La tâche 5 l'utilise.
+
+Points de conception à respecter :
+- La ligne entière est cliquable pour déplier, **mais les boutons d'action ne doivent pas déclencher le dépliement** — d'où `@click.stop` sur le conteneur des actions.
+- Le déclencheur porte `aria-expanded` et `aria-controls` pour rester utilisable au clavier.
+- Sous le point de rupture `sm`, la ligne se réorganise en carte : les colonnes deviennent des paires libellé / valeur. Les libellés sont masqués sur grand écran (`sm:hidden`), puisque l'en-tête de colonnes les porte déjà.
+- L'état d'ouverture est local à la ligne : plusieurs factures peuvent rester dépliées en même temps.
+
+- [ ] **Step 1: Récrire le composant**
+
+Remplacer entièrement le contenu de `resources/js/components/factures/FactureListItem.vue` par :
+
+```vue
+<template>
+  <div class="border-b border-gray-700 last:border-b-0" :class="{ 'bg-indigo-500/5': estDeplie }">
+    <!-- Ligne -->
+    <div
+      class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-0 px-4 py-3 hover:bg-white/[.02] transition cursor-pointer"
+      @click="basculer"
+    >
+      <!-- Chevron + numéro -->
+      <button
+        type="button"
+        class="flex items-center gap-2 text-left sm:w-[100px] shrink-0 text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
+        :aria-expanded="estDeplie"
+        :aria-controls="`facture-detail-${invoice.id}`"
+        @click.stop="basculer"
+      >
+        <span
+          class="inline-block transition-transform duration-200"
+          :class="estDeplie ? 'rotate-90' : ''"
+          aria-hidden="true"
+        >▸</span>
+        <span class="text-sm">#{{ invoice.id }}</span>
+      </button>
+
+      <!-- Client -->
+      <div class="flex-1 min-w-0">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400 mr-2">Client</span>
+        <span class="font-semibold text-white truncate">{{ nomClient }}</span>
+      </div>
+
+      <!-- Heures -->
+      <div class="sm:w-[100px] sm:text-right flex justify-between sm:block">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Heures</span>
+        <span class="text-gray-200 tabular-nums">{{ formatNombre(invoice.heures_total) }} h</span>
+      </div>
+
+      <!-- Montant -->
+      <div class="sm:w-[130px] sm:text-right flex justify-between sm:block">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Montant</span>
+        <span class="font-semibold text-white tabular-nums">{{ formatEuros(invoice.montant_total) }}</span>
+      </div>
+
+      <!-- Statut -->
+      <div class="sm:w-[160px] sm:pl-4 flex justify-between sm:block">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Statut</span>
+        <span :class="getStatusBadge(invoice.statut)">{{ getStatusText(invoice.statut) }}</span>
+      </div>
+
+      <!-- Actions : ne doivent pas déplier la ligne -->
+      <div class="flex gap-2 sm:justify-end sm:w-[200px]" @click.stop>
+        <button @click="showPdfModal = true" class="btn-action bg-gray-600 flex-1 sm:flex-none justify-center">
+          📄 <span class="sm:hidden md:inline">PDF</span>
+        </button>
+
+        <button
+          v-if="invoice.statut === 'en_attente_paiement'"
+          @click="showDeleteModal = true"
+          class="btn-action bg-red-500 flex-1 sm:flex-none justify-center"
+          aria-label="Supprimer la facture"
+        >
+          🗑️
+        </button>
+
+        <button
+          v-if="invoice.statut === 'en_attente_paiement'"
+          @click="markAsPaid(invoice)"
+          :disabled="loading.paid"
+          class="btn-action bg-green-500 disabled:opacity-50 flex-1 sm:flex-none justify-center"
+        >
+          <span v-if="loading.paid" class="animate-spin border-2 border-white border-t-transparent rounded-full w-3 h-3"></span>
+          <span v-else>✅</span>
+          <span class="sm:hidden md:inline">Payé</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Détail déplié -->
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0 -translate-y-1"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="estDeplie" :id="`facture-detail-${invoice.id}`" class="px-4 pb-4 sm:pl-14">
+        <FacturePrestationsTable :prestations="invoice.prestations ?? []" />
+      </div>
+    </Transition>
+  </div>
+
+  <!-- Modals -->
+  <FacturePdfModal v-if="showPdfModal" :invoice="invoice" @close="showPdfModal = false" />
+  <FactureDeleteModal v-if="showDeleteModal" :invoice="invoice" @close="showDeleteModal = false" />
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import {
+  FacturePdfModal,
+  FactureDeleteModal,
+  FacturePrestationsTable,
+} from '@/components/factures/';
+
+import { useInvoicesStore } from '@/stores/factures';
+import { storeToRefs } from 'pinia';
+import { formatNombre, formatEuros } from '@/utils';
+
+const invoicesStore = useInvoicesStore();
+const { paid } = invoicesStore;
+const { loading } = storeToRefs(invoicesStore);
+
+const props = defineProps({
+  invoice: {
+    type: Object,
+    required: true,
+  },
+});
+
+const estDeplie = ref(false);
+const showDeleteModal = ref(false);
+const showPdfModal = ref(false);
+
+function basculer() {
+  estDeplie.value = !estDeplie.value;
+}
+
+// Une facture sans prestation ferait planter le rendu de toute la liste.
+const nomClient = computed(() => props.invoice.prestations?.[0]?.client?.nom ?? 'Client inconnu');
+
+/**
+ * Retourne la classe CSS du badge en fonction du statut.
+ */
+function getStatusBadge(status) {
+  const base = "inline-block px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap";
+  switch (status) {
+    case 'en_attente_envoi':
+      return `${base} bg-amber-500/15 text-amber-400 ring-1 ring-amber-500/30`;
+    case 'en_attente_paiement':
+      return `${base} bg-red-500/15 text-red-400 ring-1 ring-red-500/30`;
+    case 'payé':
+      return `${base} bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/30`;
+    default:
+      return `${base} bg-gray-500/15 text-gray-300 ring-1 ring-gray-500/30`;
+  }
+}
+
+/**
+ * Retourne un texte lisible correspondant au statut.
+ */
+function getStatusText(status) {
+  switch (status) {
+    case 'en_attente_envoi':
+      return "En attente d'envoi";
+    case 'en_attente_paiement':
+      return "En attente de paiement";
+    case 'payé':
+      return "Payé";
+    default:
+      return status;
+  }
+}
+
+async function markAsPaid(invoice) {
+  await paid(invoice.id);
+}
+</script>
+```
+
+Note : l'ancien composant importait `FactureMailModal` et `formatDate` sans les utiliser réellement dans la nouvelle structure — ils ne sont volontairement pas repris. Si `FactureMailModal` était monté ailleurs, ne pas y toucher : il n'est simplement plus monté ici (il ne l'était que derrière `showMailModal`, jamais mis à `true` — code mort, comme le confirme une lecture de l'ancien fichier).
+
+- [ ] **Step 2: Vérifier le build**
+
+Run: `npm run build`
+Expected: build Vite réussi, aucun import non résolu.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/components/factures/FactureListItem.vue
+git commit -m "feat: transforme la carte de facture en ligne depliable"
+```
+
+---
+
+### Task 5 : La liste, ses filtres et ses états
+
+**Files:**
+- Modify (récriture complète) : `resources/js/components/factures/FacturesList.vue`
+- Modify : `resources/js/views/Facture.vue`
+
+**Interfaces:**
+- Consumes: `filteredInvoices`, `isAnyFilterActive`, `updateFilters`, `errors`, `loading` du store (tâche 1) ; `<FactureFilters />` (tâche 3) ; `<FactureListItem :invoice="…" />` (tâche 4).
+- Produces: `<FacturesList @create="…" />` — émet `create` quand l'utilisateur clique sur le bouton de l'état vide. `Facture.vue` l'écoute pour ouvrir le modal de création.
+
+- [ ] **Step 1: Récrire la liste**
+
+Remplacer entièrement le contenu de `resources/js/components/factures/FacturesList.vue` par :
+
+```vue
+<template>
+  <div class="mt-6">
+    <FactureFilters />
+
+    <!-- Chargement : des lignes fantômes, pas un spinner, pour que la page ne saute pas -->
+    <div v-if="loading.fetch" class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 overflow-hidden">
+      <div v-for="n in 3" :key="n" class="flex items-center gap-4 px-4 py-4 border-b border-gray-700 last:border-b-0">
+        <div class="h-4 w-12 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-4 flex-1 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-4 w-20 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-4 w-24 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-6 w-28 bg-gray-700 rounded-full animate-pulse"></div>
+      </div>
+    </div>
+
+    <!-- Erreur -->
+    <div v-else-if="errors.fetch" class="mt-6 flex justify-center bg-red-500 text-white px-6 py-3 rounded-lg shadow-lg">
+      <span class="text-xl">❌</span>
+      <p class="text-lg font-medium ml-2">{{ errors.fetch }}</p>
+    </div>
+
+    <!-- Aucune facture du tout -->
+    <div v-else-if="invoices.length === 0" class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 px-6 py-12 text-center">
+      <p class="text-3xl mb-2">📭</p>
+      <p class="text-white font-semibold mb-1">Aucune facture</p>
+      <p class="text-gray-400 mb-5">Créez votre première facture à partir de prestations non facturées.</p>
+      <button @click="emit('create')" class="btn-primary">Ajouter une facture</button>
+    </div>
+
+    <!-- Aucun résultat pour les filtres actifs : message distinct du précédent -->
+    <div v-else-if="filteredInvoices.length === 0" class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 px-6 py-12 text-center">
+      <p class="text-3xl mb-2">🔍</p>
+      <p class="text-white font-semibold mb-1">Aucun résultat</p>
+      <p class="text-gray-400 mb-5">Aucune facture ne correspond à ces filtres.</p>
+      <button @click="resetFilters" class="btn-secondary">Réinitialiser les filtres</button>
+    </div>
+
+    <!-- La liste -->
+    <div v-else class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 overflow-hidden">
+      <!-- En-tête de colonnes : masqué sur mobile, où chaque ligne devient une carte -->
+      <div class="hidden sm:flex items-center px-4 py-2 border-b border-gray-700 text-xs uppercase tracking-wide text-gray-400">
+        <span class="w-[100px] shrink-0">N°</span>
+        <span class="flex-1">Client</span>
+        <span class="w-[100px] text-right">Heures</span>
+        <span class="w-[130px] text-right">Montant</span>
+        <span class="w-[160px] pl-4">Statut</span>
+        <span class="w-[200px]"></span>
+      </div>
+
+      <FactureListItem
+        v-for="invoice in filteredInvoices"
+        :key="invoice.id"
+        :invoice="invoice"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useInvoicesStore } from '@/stores/factures';
+import { FactureListItem, FactureFilters } from '@/components/factures/';
+
+const emit = defineEmits(['create']);
+
+const invoicesStore = useInvoicesStore();
+const { fetchInvoices, updateFilters } = invoicesStore;
+const { invoices, filteredInvoices, errors, loading } = storeToRefs(invoicesStore);
+
+onMounted(() => {
+  fetchInvoices();
+});
+
+const resetFilters = () => {
+  updateFilters({
+    statut: '',
+    client_id: '',
+    month_year: '',
+  });
+};
+</script>
+```
+
+- [ ] **Step 2: Brancher l'événement de création dans la vue**
+
+Dans `resources/js/views/Facture.vue`, la liste est montée par `<FacturesList />`. La remplacer par :
+
+```html
+            <FacturesList @create="showFormModal = true" />
+```
+
+Le reste du fichier ne change pas : `showFormModal` existe déjà et pilote `<FactureFormModal>`.
+
+- [ ] **Step 3: Vérifier le build**
+
+Run: `npm run build`
+Expected: build Vite réussi.
+
+- [ ] **Step 4: Vérifier la suite backend (aucune régression attendue)**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 68 tests. Aucune tâche de ce plan ne touche au backend ; un échec ici signalerait une erreur.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/components/factures/FacturesList.vue resources/js/views/Facture.vue
+git commit -m "feat: liste dense des factures avec filtres et etats"
+```
+
+---
+
+## Vérification finale
+
+Contrôle manuel dans l'application (http://localhost:8080, onglet Factures) :
+
+- [ ] La liste s'affiche en lignes, la plus récente en haut.
+- [ ] Cliquer une ligne déplie le tableau des prestations ; recliquer le replie.
+- [ ] Deux lignes peuvent être dépliées en même temps.
+- [ ] Cliquer un bouton d'action (PDF, supprimer, payé) ne déplie PAS la ligne.
+- [ ] Le total du tableau déplié correspond au montant affiché sur la ligne.
+- [ ] Filtre statut : sélectionner « Payé » ne laisse que les factures payées.
+- [ ] Filtre client : sélectionner un client ne laisse que ses factures.
+- [ ] Filtre mois : saisir le mois des prestations (juin 2026) remonte bien la facture correspondante, même si elle a été créée en juillet.
+- [ ] Filtres combinés donnant zéro résultat : le message « Aucun résultat » s'affiche, distinct de « Aucune facture », avec un bouton de réinitialisation qui fonctionne.
+- [ ] Sur mobile (fenêtre étroite) : chaque ligne devient une carte, aucun défilement horizontal de la page.
+- [ ] Le tableau déplié défile horizontalement dans son propre conteneur sur petit écran, sans déborder.
+- [ ] Navigation clavier : le chevron est atteignable au Tab et actionnable à l'Entrée.

--- a/docs/superpowers/specs/2026-07-12-refonte-onglet-factures-design.md
+++ b/docs/superpowers/specs/2026-07-12-refonte-onglet-factures-design.md
@@ -1,0 +1,141 @@
+# Refonte de l'onglet Factures — liste dense et prestations dépliables
+
+Date : 2026-07-12
+
+## Problème
+
+`FactureListItem.vue` affiche chaque facture en carte, et déroule **toutes** ses
+prestations en blocs de quatre champs. La facture de juin 2026 compte 25
+prestations : à elle seule, sa carte fait plusieurs écrans de haut. Comme les
+cartes s'affichent dans une grille (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`)
+et que les cartes d'une même ligne s'alignent sur la plus haute, une seule
+facture volumineuse déforme toute la liste.
+
+L'onglet ne remplit donc plus son office : on ne peut ni comparer deux montants
+d'un coup d'œil, ni retrouver rapidement une facture à marquer payée.
+
+## Décisions
+
+**Une liste dense en lignes, pas une grille de cartes.** L'usage réel est de
+comparer des chiffres (montants, heures, statuts) et d'agir sur une facture, pas
+de parcourir du contenu hétérogène. Des colonnes alignées servent cet usage mieux
+que des cartes. Deux alternatives ont été écartées :
+
+- *Grille de cartes compactes avec accordéon* — corrige la hauteur, mais laisse
+  les montants dispersés dans l'espace, donc incomparables d'un regard.
+- *Cartes pleine largeur groupées par mois* — agréable, mais montre trois ou
+  quatre factures par écran pour peu d'information.
+
+**Les prestations se déplient dans la ligne**, en tableau reprenant les colonnes
+du PDF (Date, Horaires, Heures, Taux, Total) avec une ligne de total. Vérifier
+une facture à l'écran et la relire en PDF devient le même geste.
+
+**Plusieurs lignes peuvent rester dépliées simultanément.** Un accordéon exclusif
+qui referme la précédente gêne dès qu'on compare deux factures.
+
+**Filtres complets** : statut, client, mois. Le filtre par mois porte sur la
+**date des prestations**, pas sur la date de création de la facture — une facture
+de prestations de juin est créée début juillet, et c'est « la facture de juin »
+dans le langage courant. Conséquence assumée : une facture à cheval sur deux mois
+apparaît dans les deux.
+
+**Le filtrage se fait côté client**, sans appel API, comme le fait déjà le store
+des prestations. Le volume de données ne justifie pas de filtrer côté serveur.
+
+**Les horaires restent affichés dans cette vue**, même pour un client dont
+`afficher_horaires` vaut `false` : ce réglage ne concerne que le PDF envoyé au
+client, pas la vue interne.
+
+## Conception
+
+### Composants
+
+| Fichier | Responsabilité |
+|---|---|
+| `resources/js/components/factures/FacturesList.vue` (modifié) | Orchestre : filtres, états (chargement / erreur / vide / vide après filtrage), liste des lignes |
+| `resources/js/components/factures/FactureFilters.vue` (créé) | Statut, client, mois ; bouton de réinitialisation |
+| `resources/js/components/factures/FactureListItem.vue` (récrit) | Une ligne de facture, dépliable ; porte son état d'ouverture |
+| `resources/js/components/factures/FacturePrestationsTable.vue` (créé) | Le tableau des prestations affiché quand la ligne est dépliée |
+| `resources/js/stores/factures.js` (modifié) | Ajoute `activeFilters`, `updateFilters`, `isAnyFilterActive`, `filteredInvoices` |
+
+`FacturePrestationsTable` est extrait plutôt que laissé dans `FactureListItem` :
+la ligne repliée et le tableau déplié sont deux préoccupations distinctes, et
+`FactureListItem` reste lisible d'un seul tenant.
+
+`FactureFilters` suit le pattern déjà en place dans
+`resources/js/components/prestations/PrestationsFilters.vue` : les filtres actifs
+vivent dans le store, un `watch` profond appelle `updateFilters`, et un booléen
+`isAnyFilterActive` conditionne l'affichage du bouton de réinitialisation.
+
+### Le store
+
+Le store des factures gagne le même mécanisme que celui des prestations : un
+`activeFilters` (`{ statut, client_id, month_year }`, chaînes vides par défaut) et
+un `filteredInvoices` calculé.
+
+**Le tri se fait sur `invoice.id` décroissant**, pas sur `created_at`.
+`FactureResource` renvoie `created_at` au format `d/m/Y H:i:s`, une chaîne que
+JavaScript ne sait ni trier ni parser nativement ; les identifiants sont
+croissants dans le temps et donnent le même ordre sans parsing fragile. Ne pas
+« corriger » ce point en triant sur `created_at`.
+
+Le filtre par mois exploite le fait que **`PrestationResource` renvoie `date` au
+format `Y-m-d`** : la facture est retenue si au moins une de ses prestations a une
+`date` commençant par `month_year` (format `YYYY-MM`, celui que produit
+`<input type="month">`). Simple comparaison de préfixe, aucun parsing de date.
+
+Le client d'une facture se lit sur `invoice.prestations[0].client` — c'est déjà ce
+que fait le composant actuel. Cet accès est protégé (`?.`) : une facture sans
+prestation ferait planter le rendu de toute la liste, et le code actuel n'a
+aucune garde.
+
+### La ligne
+
+Repliée, elle affiche : chevron, numéro, client, heures, montant, statut, et les
+actions (PDF, supprimer, marquer payé) selon le statut — les mêmes règles
+d'affichage qu'aujourd'hui. Dépliée, le tableau des prestations apparaît
+en dessous, avec une transition de 200 ms.
+
+Le déclencheur de dépliement est un `<button>` portant `aria-expanded` et
+`aria-controls`, pour rester utilisable au clavier. Les boutons d'action sont
+dans la ligne mais ne déclenchent pas le dépliement (arrêt de la propagation).
+
+### Le responsive
+
+Les lignes sont construites en flexbox, pas en `<table>` : sous le point de
+rupture `sm`, chaque ligne se réorganise en carte (les colonnes deviennent des
+paires libellé/valeur) sans jamais provoquer de défilement horizontal. Le tableau
+des prestations déplié, lui, défile horizontalement dans son propre conteneur sur
+petit écran.
+
+### Les états
+
+Quatre états distincts, tous couverts :
+
+- **Chargement** : des lignes fantômes (skeleton), pas un spinner — la page ne
+  saute pas quand les données arrivent.
+- **Erreur** : le message d'erreur du store, comme aujourd'hui.
+- **Aucune facture** : message d'accueil et bouton « Ajouter une facture ».
+- **Aucun résultat après filtrage** : message *distinct* du précédent, avec un
+  bouton « Réinitialiser les filtres ». Confondre les deux fait croire à
+  l'utilisateur qu'il a perdu ses données.
+
+## Tests
+
+Le projet n'a pas de tests front. La vérification repose sur :
+
+- `npm run build` — attrape les erreurs de compilation Vue.
+- La suite Feature (`php artisan test --testsuite=Feature`), qui doit rester
+  verte : aucun changement backend n'est prévu.
+- Un passage manuel dans l'application : déplier/replier, appliquer chaque
+  filtre, vérifier les quatre états, et contrôler le rendu mobile.
+
+Installer Vitest pour tester la logique de filtrage (qui est du calcul pur)
+serait défendable, mais dépasse le périmètre : ce serait introduire une chaîne de
+test front entière pour cette seule fonctionnalité. À considérer séparément.
+
+## Hors périmètre
+
+- Le backend : aucune modification d'API, de modèle ou de migration.
+- Les modals (PDF, suppression, mail, création) : inchangés.
+- Le dashboard et l'onglet Prestations.

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,36 +1,36 @@
 {
-  "_ClientFormModal-rlFfuo06.js": {
-    "file": "assets/ClientFormModal-rlFfuo06.js",
+  "_ClientFormModal-B1hl8dte.js": {
+    "file": "assets/ClientFormModal-B1hl8dte.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js",
-      "_clients-DefvV8wt.js"
+      "_clients-B1XWkNiB.js"
     ]
   },
-  "_FactureFormModal-CaxtkXzi.js": {
-    "file": "assets/FactureFormModal-CaxtkXzi.js",
+  "_FactureFormModal-xzSlDvy8.js": {
+    "file": "assets/FactureFormModal-xzSlDvy8.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-BmbIFofF.js"
+      "_prestations-B3Iy6jh-.js"
     ]
   },
-  "_TauxHoraireFormModal-Cf2huaZ5.js": {
-    "file": "assets/TauxHoraireFormModal-Cf2huaZ5.js",
+  "_TauxHoraireFormModal-B_TCbM-Z.js": {
+    "file": "assets/TauxHoraireFormModal-B_TCbM-Z.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_clients-DefvV8wt.js": {
-    "file": "assets/clients-DefvV8wt.js",
+  "_clients-B1XWkNiB.js": {
+    "file": "assets/clients-B1XWkNiB.js",
     "name": "clients",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-BmbIFofF.js": {
-    "file": "assets/prestations-BmbIFofF.js",
+  "_prestations-B3Iy6jh-.js": {
+    "file": "assets/prestations-B3Iy6jh-.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -43,7 +43,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-wl3FAOQf.css",
+    "file": "assets/app-CZJdDRy-.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -56,7 +56,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-DD3sBOU2.js",
+    "file": "assets/app-DBn4y_n7.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -74,54 +74,54 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-xdXV3Sxd.js",
+    "file": "assets/Client-C8wUc4dU.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_clients-DefvV8wt.js",
-      "_ClientFormModal-rlFfuo06.js"
+      "_clients-B1XWkNiB.js",
+      "_ClientFormModal-B1hl8dte.js"
     ],
     "css": [
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-DMnIMhSt.js",
+    "file": "assets/Dashboard-b7Ej6ALO.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-CaxtkXzi.js",
-      "_prestations-BmbIFofF.js"
+      "_FactureFormModal-xzSlDvy8.js",
+      "_prestations-B3Iy6jh-.js"
     ],
     "css": [
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-ZOHv7Rx6.js",
+    "file": "assets/Facture-D2lAghrh.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-CaxtkXzi.js",
-      "_clients-DefvV8wt.js",
-      "_prestations-BmbIFofF.js"
+      "_FactureFormModal-xzSlDvy8.js",
+      "_clients-B1XWkNiB.js",
+      "_prestations-B3Iy6jh-.js"
     ],
     "css": [
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-CYiv2c9s.js",
+    "file": "assets/Login-ZbhayUcr.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -129,11 +129,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-mp916j2C.js",
+    "file": "assets/NotFound-DRn253xs.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -141,27 +141,27 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-BJD8EdO3.js",
+    "file": "assets/Prestation-D-JlMYRa.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-BmbIFofF.js",
-      "_clients-DefvV8wt.js",
-      "_TauxHoraireFormModal-Cf2huaZ5.js",
-      "_ClientFormModal-rlFfuo06.js"
+      "_prestations-B3Iy6jh-.js",
+      "_clients-B1XWkNiB.js",
+      "_TauxHoraireFormModal-B_TCbM-Z.js",
+      "_ClientFormModal-B1hl8dte.js"
     ],
     "css": [
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-kaSxKZrD.js",
+    "file": "assets/Profile-BcEvL1R2.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -170,11 +170,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-BNDx-jYh.js",
+    "file": "assets/PwaStatus-B73YUG0n.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -183,23 +183,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-chlsZJlU.js",
+    "file": "assets/TauxHoraire-DHWMU-H2.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-Cf2huaZ5.js"
+      "_TauxHoraireFormModal-B_TCbM-Z.js"
     ],
     "css": [
-      "assets/app-wl3FAOQf.css"
+      "assets/app-CZJdDRy-.css"
     ]
   }
 }

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,28 +1,28 @@
 {
-  "_ClientFormModal-DzOamBmx.js": {
-    "file": "assets/ClientFormModal-DzOamBmx.js",
+  "_ClientFormModal-5-5Qj3yv.js": {
+    "file": "assets/ClientFormModal-5-5Qj3yv.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_FactureFormModal-DM_2-ZmD.js": {
-    "file": "assets/FactureFormModal-DM_2-ZmD.js",
+  "_FactureFormModal-Bkfy8YDB.js": {
+    "file": "assets/FactureFormModal-Bkfy8YDB.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-DvXuxl5t.js"
+      "_prestations-D19PXJVM.js"
     ]
   },
-  "_TauxHoraireFormModal-LCvb2Uvh.js": {
-    "file": "assets/TauxHoraireFormModal-LCvb2Uvh.js",
+  "_TauxHoraireFormModal-Ck41p_W9.js": {
+    "file": "assets/TauxHoraireFormModal-Ck41p_W9.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-DvXuxl5t.js": {
-    "file": "assets/prestations-DvXuxl5t.js",
+  "_prestations-D19PXJVM.js": {
+    "file": "assets/prestations-D19PXJVM.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -35,7 +35,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-C2Kpw-il.css",
+    "file": "assets/app-wl3FAOQf.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -48,7 +48,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-HmLDUmDv.js",
+    "file": "assets/app-BGMfvhVI.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -66,52 +66,52 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-BByHK5n5.js",
+    "file": "assets/Client-DclmB6EX.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_ClientFormModal-DzOamBmx.js"
+      "_ClientFormModal-5-5Qj3yv.js"
     ],
     "css": [
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-Cyl49xNQ.js",
+    "file": "assets/Dashboard-BPgrGwOG.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-DM_2-ZmD.js",
-      "_prestations-DvXuxl5t.js"
+      "_FactureFormModal-Bkfy8YDB.js",
+      "_prestations-D19PXJVM.js"
     ],
     "css": [
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-Ti9kKosR.js",
+    "file": "assets/Facture-Cu2CHPpW.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
-      "_FactureFormModal-DM_2-ZmD.js",
+      "_FactureFormModal-Bkfy8YDB.js",
       "resources/js/app.js",
-      "_prestations-DvXuxl5t.js"
+      "_prestations-D19PXJVM.js"
     ],
     "css": [
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-Co-t4MXu.js",
+    "file": "assets/Login-C_wymkZw.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -119,11 +119,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-BaaVp5hJ.js",
+    "file": "assets/NotFound-BFmZrG6b.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -131,26 +131,26 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-BB9441kc.js",
+    "file": "assets/Prestation-YnDJEybB.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-DvXuxl5t.js",
-      "_ClientFormModal-DzOamBmx.js",
-      "_TauxHoraireFormModal-LCvb2Uvh.js"
+      "_prestations-D19PXJVM.js",
+      "_ClientFormModal-5-5Qj3yv.js",
+      "_TauxHoraireFormModal-Ck41p_W9.js"
     ],
     "css": [
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-AJ94-J8p.js",
+    "file": "assets/Profile-D_2RTsxk.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -159,11 +159,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-Bc4-W2Yf.js",
+    "file": "assets/PwaStatus-C5nyIZZW.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -172,23 +172,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-BGfc1Poq.js",
+    "file": "assets/TauxHoraire-Bk_9Pt5d.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-LCvb2Uvh.js"
+      "_TauxHoraireFormModal-Ck41p_W9.js"
     ],
     "css": [
-      "assets/app-C2Kpw-il.css"
+      "assets/app-wl3FAOQf.css"
     ]
   }
 }

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,36 +1,36 @@
 {
-  "_ClientFormModal-B1hl8dte.js": {
-    "file": "assets/ClientFormModal-B1hl8dte.js",
+  "_ClientFormModal-GCgMqq6G.js": {
+    "file": "assets/ClientFormModal-GCgMqq6G.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js",
-      "_clients-B1XWkNiB.js"
+      "_clients-C3dYXxt1.js"
     ]
   },
-  "_FactureFormModal-xzSlDvy8.js": {
-    "file": "assets/FactureFormModal-xzSlDvy8.js",
+  "_FactureFormModal-DZA4aDsH.js": {
+    "file": "assets/FactureFormModal-DZA4aDsH.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-B3Iy6jh-.js"
+      "_prestations-D9cDnY7n.js"
     ]
   },
-  "_TauxHoraireFormModal-B_TCbM-Z.js": {
-    "file": "assets/TauxHoraireFormModal-B_TCbM-Z.js",
+  "_TauxHoraireFormModal-8wvQDqp3.js": {
+    "file": "assets/TauxHoraireFormModal-8wvQDqp3.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_clients-B1XWkNiB.js": {
-    "file": "assets/clients-B1XWkNiB.js",
+  "_clients-C3dYXxt1.js": {
+    "file": "assets/clients-C3dYXxt1.js",
     "name": "clients",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-B3Iy6jh-.js": {
-    "file": "assets/prestations-B3Iy6jh-.js",
+  "_prestations-D9cDnY7n.js": {
+    "file": "assets/prestations-D9cDnY7n.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -43,7 +43,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-CZJdDRy-.css",
+    "file": "assets/app-CJYZKmOp.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -56,7 +56,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-DBn4y_n7.js",
+    "file": "assets/app-Dwq1HFlA.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -74,54 +74,54 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-C8wUc4dU.js",
+    "file": "assets/Client-D5jk39UI.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_clients-B1XWkNiB.js",
-      "_ClientFormModal-B1hl8dte.js"
+      "_clients-C3dYXxt1.js",
+      "_ClientFormModal-GCgMqq6G.js"
     ],
     "css": [
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-b7Ej6ALO.js",
+    "file": "assets/Dashboard-CDIq0OhC.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-xzSlDvy8.js",
-      "_prestations-B3Iy6jh-.js"
+      "_FactureFormModal-DZA4aDsH.js",
+      "_prestations-D9cDnY7n.js"
     ],
     "css": [
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-D2lAghrh.js",
+    "file": "assets/Facture--loJcITR.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-xzSlDvy8.js",
-      "_clients-B1XWkNiB.js",
-      "_prestations-B3Iy6jh-.js"
+      "_FactureFormModal-DZA4aDsH.js",
+      "_clients-C3dYXxt1.js",
+      "_prestations-D9cDnY7n.js"
     ],
     "css": [
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-ZbhayUcr.js",
+    "file": "assets/Login-BDDsIwON.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -129,11 +129,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-DRn253xs.js",
+    "file": "assets/NotFound-BXHRu_Nv.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -141,27 +141,27 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-D-JlMYRa.js",
+    "file": "assets/Prestation-DZe5ymES.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-B3Iy6jh-.js",
-      "_clients-B1XWkNiB.js",
-      "_TauxHoraireFormModal-B_TCbM-Z.js",
-      "_ClientFormModal-B1hl8dte.js"
+      "_prestations-D9cDnY7n.js",
+      "_clients-C3dYXxt1.js",
+      "_TauxHoraireFormModal-8wvQDqp3.js",
+      "_ClientFormModal-GCgMqq6G.js"
     ],
     "css": [
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-BcEvL1R2.js",
+    "file": "assets/Profile-DLbfgaer.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -170,11 +170,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-B73YUG0n.js",
+    "file": "assets/PwaStatus-CWZQoADd.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -183,23 +183,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-DHWMU-H2.js",
+    "file": "assets/TauxHoraire-DvLAqn10.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-B_TCbM-Z.js"
+      "_TauxHoraireFormModal-8wvQDqp3.js"
     ],
     "css": [
-      "assets/app-CZJdDRy-.css"
+      "assets/app-CJYZKmOp.css"
     ]
   }
 }

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,28 +1,36 @@
 {
-  "_ClientFormModal-5-5Qj3yv.js": {
-    "file": "assets/ClientFormModal-5-5Qj3yv.js",
+  "_ClientFormModal-rlFfuo06.js": {
+    "file": "assets/ClientFormModal-rlFfuo06.js",
     "name": "ClientFormModal",
     "imports": [
-      "resources/js/app.js"
+      "resources/js/app.js",
+      "_clients-DefvV8wt.js"
     ]
   },
-  "_FactureFormModal-Bkfy8YDB.js": {
-    "file": "assets/FactureFormModal-Bkfy8YDB.js",
+  "_FactureFormModal-CaxtkXzi.js": {
+    "file": "assets/FactureFormModal-CaxtkXzi.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-D19PXJVM.js"
+      "_prestations-BmbIFofF.js"
     ]
   },
-  "_TauxHoraireFormModal-Ck41p_W9.js": {
-    "file": "assets/TauxHoraireFormModal-Ck41p_W9.js",
+  "_TauxHoraireFormModal-Cf2huaZ5.js": {
+    "file": "assets/TauxHoraireFormModal-Cf2huaZ5.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-D19PXJVM.js": {
-    "file": "assets/prestations-D19PXJVM.js",
+  "_clients-DefvV8wt.js": {
+    "file": "assets/clients-DefvV8wt.js",
+    "name": "clients",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_prestations-BmbIFofF.js": {
+    "file": "assets/prestations-BmbIFofF.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -48,7 +56,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-BGMfvhVI.js",
+    "file": "assets/app-DD3sBOU2.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -70,48 +78,50 @@
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-DclmB6EX.js",
+    "file": "assets/Client-xdXV3Sxd.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_ClientFormModal-5-5Qj3yv.js"
+      "_clients-DefvV8wt.js",
+      "_ClientFormModal-rlFfuo06.js"
     ],
     "css": [
       "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-BPgrGwOG.js",
+    "file": "assets/Dashboard-DMnIMhSt.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-Bkfy8YDB.js",
-      "_prestations-D19PXJVM.js"
+      "_FactureFormModal-CaxtkXzi.js",
+      "_prestations-BmbIFofF.js"
     ],
     "css": [
       "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-Cu2CHPpW.js",
+    "file": "assets/Facture-ZOHv7Rx6.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
-      "_FactureFormModal-Bkfy8YDB.js",
       "resources/js/app.js",
-      "_prestations-D19PXJVM.js"
+      "_FactureFormModal-CaxtkXzi.js",
+      "_clients-DefvV8wt.js",
+      "_prestations-BmbIFofF.js"
     ],
     "css": [
       "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-C_wymkZw.js",
+    "file": "assets/Login-CYiv2c9s.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -123,7 +133,7 @@
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-BFmZrG6b.js",
+    "file": "assets/NotFound-mp916j2C.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -135,22 +145,23 @@
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-YnDJEybB.js",
+    "file": "assets/Prestation-BJD8EdO3.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-D19PXJVM.js",
-      "_ClientFormModal-5-5Qj3yv.js",
-      "_TauxHoraireFormModal-Ck41p_W9.js"
+      "_prestations-BmbIFofF.js",
+      "_clients-DefvV8wt.js",
+      "_TauxHoraireFormModal-Cf2huaZ5.js",
+      "_ClientFormModal-rlFfuo06.js"
     ],
     "css": [
       "assets/app-wl3FAOQf.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-D_2RTsxk.js",
+    "file": "assets/Profile-kaSxKZrD.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -163,7 +174,7 @@
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-C5nyIZZW.js",
+    "file": "assets/PwaStatus-BNDx-jYh.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -179,13 +190,13 @@
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-Bk_9Pt5d.js",
+    "file": "assets/TauxHoraire-chlsZJlU.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-Ck41p_W9.js"
+      "_TauxHoraireFormModal-Cf2huaZ5.js"
     ],
     "css": [
       "assets/app-wl3FAOQf.css"

--- a/resources/js/components/factures/FactureFilters.vue
+++ b/resources/js/components/factures/FactureFilters.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="bg-gray-800 p-4 rounded-lg shadow-lg flex flex-col sm:flex-row gap-4 sm:items-end">
+    <div class="flex-1">
+      <label for="filtre-statut" class="text-sm text-gray-300 font-semibold">Statut :</label>
+      <select id="filtre-statut" v-model="activeFilters.statut" class="filter-input">
+        <option value="">Tous les statuts</option>
+        <option value="en_attente_envoi">En attente d'envoi</option>
+        <option value="en_attente_paiement">En attente de paiement</option>
+        <option value="payé">Payé</option>
+      </select>
+    </div>
+
+    <div class="flex-1">
+      <label for="filtre-client" class="text-sm text-gray-300 font-semibold">Client :</label>
+      <select id="filtre-client" v-model="activeFilters.client_id" class="filter-input">
+        <option value="">Tous les clients</option>
+        <option v-for="client in clients" :key="client.id" :value="client.id">
+          {{ client.nom }}
+        </option>
+      </select>
+    </div>
+
+    <div class="flex-1">
+      <label for="filtre-mois" class="text-sm text-gray-300 font-semibold">Mois des prestations :</label>
+      <input id="filtre-mois" type="month" v-model="activeFilters.month_year" class="filter-input" />
+    </div>
+
+    <button v-if="isAnyFilterActive" @click="resetFilters" class="btn-secondary whitespace-nowrap">
+      Réinitialiser
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, watch } from 'vue';
+import { useInvoicesStore } from '@/stores/factures';
+import { useClientsStore } from '@/stores/clients';
+import { storeToRefs } from 'pinia';
+
+const invoicesStore = useInvoicesStore();
+const clientsStore = useClientsStore();
+
+const { activeFilters, isAnyFilterActive } = storeToRefs(invoicesStore);
+const { updateFilters } = invoicesStore;
+
+const { fetchClients } = clientsStore;
+const { clients } = storeToRefs(clientsStore);
+
+onMounted(() => {
+  fetchClients();
+});
+
+watch(activeFilters, (newFilters) => {
+  updateFilters(newFilters);
+}, { deep: true });
+
+const resetFilters = () => {
+  updateFilters({
+    statut: '',
+    client_id: '',
+    month_year: '',
+  });
+};
+</script>

--- a/resources/js/components/factures/FactureListItem.vue
+++ b/resources/js/components/factures/FactureListItem.vue
@@ -1,132 +1,153 @@
 <template>
-    <div class="bg-gray-800 p-6 rounded-lg shadow-lg flex flex-col space-y-4">
-        <!-- En-tête -->
-        <div class="flex justify-between items-center border-b pb-3">
-            <h2 class="text-xl font-semibold text-white flex items-center gap-2">
-              🧾 Facture #{{ invoice.id }}
-            </h2>
+  <div class="border-b border-gray-700 last:border-b-0" :class="{ 'bg-indigo-500/5': estDeplie }">
+    <!-- Ligne -->
+    <div
+      class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-0 px-4 py-3 hover:bg-white/[.02] transition cursor-pointer"
+      @click="basculer"
+    >
+      <!-- Chevron + numéro -->
+      <button
+        type="button"
+        class="flex items-center gap-2 text-left sm:w-[100px] shrink-0 text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
+        :aria-expanded="estDeplie"
+        :aria-controls="`facture-detail-${invoice.id}`"
+        @click.stop="basculer"
+      >
+        <span
+          class="inline-block transition-transform duration-200"
+          :class="estDeplie ? 'rotate-90' : ''"
+          aria-hidden="true"
+        >▸</span>
+        <span class="text-sm">#{{ invoice.id }}</span>
+      </button>
 
-            <span :class="getStatusBadge(invoice.statut)">
-                {{ getStatusText(invoice.statut) }}
-            </span>
-          </div>
-          
-          <!-- Détails de la facturation -->
-          <div class="bg-gray-900 p-4 rounded-md space-y-2">
-            <p class="text-gray-300 text-lg">
-              ⏱️ <span class="font-semibold text-white">{{ invoice.heures_total }} h</span>  
-            </p>
-            <p class="text-gray-300 text-lg">
-              💶 <span class="font-semibold text-white">{{ invoice.montant_total }} €</span> 
-            </p>
-          </div>
-          
-          <!-- Informations Client -->
-          <div class="bg-gray-900 p-4 rounded-lg flex flex-col space-y-3">
-            <h3 class="text-lg font-semibold text-white flex items-center gap-2">
-              <span class="text-indigo-300 text-xl">👤</span>
-              {{ invoice.prestations[0].client.nom }}
-            </h3>
-          </div>
-
-          <!-- Informations Prestations -->
-          <div class="bg-gray-900 p-4 rounded-lg flex flex-col space-y-3">
-            <h3 class="text-lg font-semibold text-white flex items-center gap-2">
-              <span class="text-indigo-300 text-xl">💼</span>
-              Prestations
-            </h3>
-
-            <div v-for="prestation in invoice.prestations" :key="prestation.id" class="bg-gray-800 p-3 rounded-md grid grid-cols-2">
-              <p class="text-gray-300 text-md flex items-center">
-                📆 <span class="ml-2 font-semibold text-white">{{ formatDate(prestation.date) }}</span>
-              </p>
-              <p class="text-gray-300 text-md flex items-center">
-                💵 <span class="ml-2 font-semibold text-white">{{ prestation.heures * prestation.taux_horaire.taux }} €</span>
-              </p>
-              <p class="text-gray-300 text-md flex items-center">
-                💰 <span class="ml-2 font-semibold text-white">{{ prestation.taux_horaire.taux }} € / h</span>
-              </p>
-              <p class="text-gray-300 text-md flex items-center">
-                ⏳ <span class="ml-2 font-semibold text-white">{{ prestation.heures }} h</span>
-              </p>
-              
-            </div>
-          </div>
-
-        <!-- ⏳ Statuts et dates clés -->
-        <div class="bg-gray-900 p-4 rounded-md
-        ">
-          <p class="text-gray-300 text-lg">
-            ✅ <span class="font-semibold text-white">Payée le :</span> {{ invoice.paye_le !== null ? invoice.paye_le : "Non payée" }}
-          </p>
+      <!-- Client -->
+      <div class="flex-1 min-w-0">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400 mr-2">Client</span>
+        <span class="font-semibold text-white truncate">{{ nomClient }}</span>
       </div>
 
-        <!-- 🔘 Actions -->
-        <div class="flex flex-wrap justify-center gap-3 mt-4">
-          <button @click="showPdfModal = true" class="btn-action bg-gray-600">
-              📄 Voir
-          </button>
+      <!-- Heures -->
+      <div class="sm:w-[100px] sm:text-right flex justify-between sm:block">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Heures</span>
+        <span class="text-gray-200 tabular-nums">{{ formatNombre(invoice.heures_total) }} h</span>
+      </div>
 
-          <button v-if="invoice.statut === 'en_attente_paiement'" @click="showDeleteModal = true" class="btn-action bg-red-500">
-              🗑️ Supprimer
-          </button>
+      <!-- Montant -->
+      <div class="sm:w-[130px] sm:text-right flex justify-between sm:block">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Montant</span>
+        <span class="font-semibold text-white tabular-nums">{{ formatEuros(invoice.montant_total) }}</span>
+      </div>
 
-          <button v-if="invoice.statut === 'en_attente_paiement'" @click="markAsPaid(invoice)" :disabled="loading.paid"
-              class="btn-action bg-green-500 disabled:opacity-50">
-              <span v-if="loading.paid" class="animate-spin border-4 border-white border-t-transparent rounded-full w-4 h-4"></span>
-              ✅ Payé
-          </button>
+      <!-- Statut -->
+      <div class="sm:w-[160px] sm:pl-4 flex justify-between sm:block">
+        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Statut</span>
+        <span :class="getStatusBadge(invoice.statut)">{{ getStatusText(invoice.statut) }}</span>
+      </div>
+
+      <!-- Actions : ne doivent pas déplier la ligne -->
+      <div class="flex gap-2 sm:justify-end sm:w-[200px]" @click.stop>
+        <button @click="showPdfModal = true" class="btn-action bg-gray-600 flex-1 sm:flex-none justify-center">
+          📄 <span class="sm:hidden md:inline">PDF</span>
+        </button>
+
+        <button
+          v-if="invoice.statut === 'en_attente_paiement'"
+          @click="showDeleteModal = true"
+          class="btn-action bg-red-500 flex-1 sm:flex-none justify-center"
+          aria-label="Supprimer la facture"
+        >
+          🗑️
+        </button>
+
+        <button
+          v-if="invoice.statut === 'en_attente_paiement'"
+          @click="markAsPaid(invoice)"
+          :disabled="loading.paid"
+          class="btn-action bg-green-500 disabled:opacity-50 flex-1 sm:flex-none justify-center"
+        >
+          <span v-if="loading.paid" class="animate-spin border-2 border-white border-t-transparent rounded-full w-3 h-3"></span>
+          <span v-else>✅</span>
+          <span class="sm:hidden md:inline">Payé</span>
+        </button>
       </div>
     </div>
 
-    <!-- Modals -->
-    <FacturePdfModal v-if="showPdfModal" :invoice="invoice" @close="showPdfModal = false" />
-    <FactureDeleteModal v-if="showDeleteModal" :invoice="invoice" @close="showDeleteModal = false" />
-    <FactureMailModal v-if="showMailModal" :invoice="invoice" @close="showMailModal = false" />
+    <!-- Détail déplié -->
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0 -translate-y-1"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="estDeplie" :id="`facture-detail-${invoice.id}`" class="px-4 pb-4 sm:pl-14">
+        <FacturePrestationsTable :prestations="invoice.prestations ?? []" />
+      </div>
+    </Transition>
+  </div>
+
+  <!-- Modals -->
+  <FacturePdfModal v-if="showPdfModal" :invoice="invoice" @close="showPdfModal = false" />
+  <FactureDeleteModal v-if="showDeleteModal" :invoice="invoice" @close="showDeleteModal = false" />
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { 
-    FacturePdfModal,
-    FactureDeleteModal, 
-    FactureMailModal,
-} from '@/components/factures/'
+import { ref, computed } from 'vue';
+import {
+  FacturePdfModal,
+  FactureDeleteModal,
+  FacturePrestationsTable,
+} from '@/components/factures/';
 
-import { formatDate } from '@/utils'
-import { useInvoicesStore } from '@/stores/factures'
-import { storeToRefs } from 'pinia'
+import { useInvoicesStore } from '@/stores/factures';
+import { storeToRefs } from 'pinia';
+import { formatNombre, formatEuros } from '@/utils';
 
-const invoicesStore = useInvoicesStore()
-const { paid } = invoicesStore
-const { loading } = storeToRefs(invoicesStore)
+const invoicesStore = useInvoicesStore();
+const { paid } = invoicesStore;
+const { loading } = storeToRefs(invoicesStore);
 
 const props = defineProps({
-    invoice: Object,
-})
+  invoice: {
+    type: Object,
+    required: true,
+  },
+});
 
-const showDeleteModal = ref(false)
-const showPdfModal = ref(false)
-const showMailModal = ref(false)
+const estDeplie = ref(false);
+const showDeleteModal = ref(false);
+const showPdfModal = ref(false);
+
+function basculer() {
+  estDeplie.value = !estDeplie.value;
+}
+
+// Une facture sans prestation ferait planter le rendu de toute la liste.
+const nomClient = computed(() => props.invoice.prestations?.[0]?.client?.nom ?? 'Client inconnu');
 
 /**
  * Retourne la classe CSS du badge en fonction du statut.
  */
- function getStatusBadge(status) {
+function getStatusBadge(status) {
+  const base = "inline-block px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap";
   switch (status) {
+    case 'en_attente_envoi':
+      return `${base} bg-amber-500/15 text-amber-400 ring-1 ring-amber-500/30`;
     case 'en_attente_paiement':
-      return "bg-red-500 text-white px-3 py-1 rounded-full text-xs";
+      return `${base} bg-red-500/15 text-red-400 ring-1 ring-red-500/30`;
     case 'payé':
-      return "bg-green-500 text-white px-3 py-1 rounded-full text-xs";
+      return `${base} bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/30`;
     default:
-      return "bg-gray-500 text-white px-3 py-1 rounded-full text-xs";
+      return `${base} bg-gray-500/15 text-gray-300 ring-1 ring-gray-500/30`;
   }
 }
 
 /**
  * Retourne un texte lisible correspondant au statut.
  */
- function getStatusText(status) {
+function getStatusText(status) {
   switch (status) {
     case 'en_attente_envoi':
       return "En attente d'envoi";
@@ -139,8 +160,7 @@ const showMailModal = ref(false)
   }
 }
 
-// 📌 Marquer la facture comme payée avec chargement
 async function markAsPaid(invoice) {
-    await paid(invoice.id)
+  await paid(invoice.id);
 }
 </script>

--- a/resources/js/components/factures/FactureListItem.vue
+++ b/resources/js/components/factures/FactureListItem.vue
@@ -22,9 +22,9 @@
       </button>
 
       <!-- Client -->
-      <div class="flex-1 min-w-0">
+      <div class="flex-1 min-w-0 overflow-hidden">
         <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400 mr-2">Client</span>
-        <span class="font-semibold text-white truncate">{{ nomClient }}</span>
+        <span class="block truncate font-semibold text-white">{{ nomClient }}</span>
       </div>
 
       <!-- Heures -->
@@ -48,7 +48,7 @@
       <!-- Actions : ne doivent pas déplier la ligne -->
       <div class="flex gap-2 sm:justify-end sm:w-[200px]" @click.stop>
         <button @click="showPdfModal = true" class="btn-action bg-gray-600 flex-1 sm:flex-none justify-center">
-          📄 <span class="sm:hidden md:inline">PDF</span>
+          📄 <span class="sm:hidden lg:inline">PDF</span>
         </button>
 
         <button
@@ -68,7 +68,7 @@
         >
           <span v-if="loading.paid" class="animate-spin border-2 border-white border-t-transparent rounded-full w-3 h-3"></span>
           <span v-else>✅</span>
-          <span class="sm:hidden md:inline">Payé</span>
+          <span class="sm:hidden lg:inline">Payé</span>
         </button>
       </div>
     </div>
@@ -82,8 +82,8 @@
       leave-from-class="opacity-100"
       leave-to-class="opacity-0"
     >
-      <div v-if="estDeplie" :id="`facture-detail-${invoice.id}`" class="px-4 pb-4 sm:pl-14">
-        <FacturePrestationsTable :prestations="invoice.prestations ?? []" />
+      <div v-show="estDeplie" :id="`facture-detail-${invoice.id}`" class="px-4 pb-4 sm:pl-14">
+        <FacturePrestationsTable :invoice="invoice" />
       </div>
     </Transition>
   </div>

--- a/resources/js/components/factures/FactureListItem.vue
+++ b/resources/js/components/factures/FactureListItem.vue
@@ -2,13 +2,13 @@
   <div class="border-b border-gray-700 last:border-b-0" :class="{ 'bg-indigo-500/5': estDeplie }">
     <!-- Ligne -->
     <div
-      class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-0 px-4 py-3 hover:bg-white/[.02] transition cursor-pointer"
+      class="flex flex-col lg:flex-row lg:items-center gap-3 lg:gap-0 px-4 py-3 hover:bg-white/[.02] transition cursor-pointer"
       @click="basculer"
     >
       <!-- Chevron + numéro -->
       <button
         type="button"
-        class="flex items-center gap-2 text-left sm:w-[100px] shrink-0 text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
+        class="flex items-center gap-2 text-left lg:w-[100px] shrink-0 text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
         :aria-expanded="estDeplie"
         :aria-controls="`facture-detail-${invoice.id}`"
         @click.stop="basculer"
@@ -23,38 +23,38 @@
 
       <!-- Client -->
       <div class="flex-1 min-w-0 overflow-hidden">
-        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400 mr-2">Client</span>
+        <span class="lg:hidden text-xs uppercase tracking-wide text-gray-400 mr-2">Client</span>
         <span class="block truncate font-semibold text-white">{{ nomClient }}</span>
       </div>
 
       <!-- Heures -->
-      <div class="sm:w-[100px] sm:text-right flex justify-between sm:block">
-        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Heures</span>
+      <div class="lg:w-[100px] lg:text-right flex justify-between lg:block">
+        <span class="lg:hidden text-xs uppercase tracking-wide text-gray-400">Heures</span>
         <span class="text-gray-200 tabular-nums">{{ formatNombre(invoice.heures_total) }} h</span>
       </div>
 
       <!-- Montant -->
-      <div class="sm:w-[130px] sm:text-right flex justify-between sm:block">
-        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Montant</span>
+      <div class="lg:w-[130px] lg:text-right flex justify-between lg:block">
+        <span class="lg:hidden text-xs uppercase tracking-wide text-gray-400">Montant</span>
         <span class="font-semibold text-white tabular-nums">{{ formatEuros(invoice.montant_total) }}</span>
       </div>
 
       <!-- Statut -->
-      <div class="sm:w-[160px] sm:pl-4 flex justify-between sm:block">
-        <span class="sm:hidden text-xs uppercase tracking-wide text-gray-400">Statut</span>
+      <div class="lg:w-[180px] lg:pl-4 flex justify-between lg:block">
+        <span class="lg:hidden text-xs uppercase tracking-wide text-gray-400">Statut</span>
         <span :class="getStatusBadge(invoice.statut)">{{ getStatusText(invoice.statut) }}</span>
       </div>
 
       <!-- Actions : ne doivent pas déplier la ligne -->
-      <div class="flex gap-2 sm:justify-end sm:w-[200px]" @click.stop>
-        <button @click="showPdfModal = true" class="btn-action bg-gray-600 flex-1 sm:flex-none justify-center">
-          📄 <span class="sm:hidden lg:inline">PDF</span>
+      <div class="flex gap-2 lg:justify-end lg:w-[240px]" @click.stop>
+        <button @click="showPdfModal = true" class="btn-action bg-gray-600 flex-1 lg:flex-none justify-center">
+          📄 <span>PDF</span>
         </button>
 
         <button
           v-if="invoice.statut === 'en_attente_paiement'"
           @click="showDeleteModal = true"
-          class="btn-action bg-red-500 flex-1 sm:flex-none justify-center"
+          class="btn-action bg-red-500 flex-1 lg:flex-none justify-center"
           aria-label="Supprimer la facture"
         >
           🗑️
@@ -64,11 +64,11 @@
           v-if="invoice.statut === 'en_attente_paiement'"
           @click="markAsPaid(invoice)"
           :disabled="loading.paid"
-          class="btn-action bg-green-500 disabled:opacity-50 flex-1 sm:flex-none justify-center"
+          class="btn-action bg-green-500 disabled:opacity-50 flex-1 lg:flex-none justify-center"
         >
           <span v-if="loading.paid" class="animate-spin border-2 border-white border-t-transparent rounded-full w-3 h-3"></span>
           <span v-else>✅</span>
-          <span class="sm:hidden lg:inline">Payé</span>
+          <span>Payé</span>
         </button>
       </div>
     </div>
@@ -82,7 +82,7 @@
       leave-from-class="opacity-100"
       leave-to-class="opacity-0"
     >
-      <div v-show="estDeplie" :id="`facture-detail-${invoice.id}`" class="px-4 pb-4 sm:pl-14">
+      <div v-show="estDeplie" :id="`facture-detail-${invoice.id}`" class="px-4 pb-4 lg:pl-14">
         <FacturePrestationsTable :invoice="invoice" />
       </div>
     </Transition>

--- a/resources/js/components/factures/FacturePrestationsTable.vue
+++ b/resources/js/components/factures/FacturePrestationsTable.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="overflow-x-auto rounded-lg bg-gray-950/60 ring-1 ring-gray-700">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="text-left text-xs uppercase tracking-wide text-gray-400">
+          <th class="px-3 py-2 font-medium">Date</th>
+          <th class="px-3 py-2 font-medium">Horaires</th>
+          <th class="px-3 py-2 font-medium text-right">Heures</th>
+          <th class="px-3 py-2 font-medium text-right">Taux</th>
+          <th class="px-3 py-2 font-medium text-right">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="prestation in prestations"
+          :key="prestation.id"
+          class="border-t border-gray-800 text-gray-200"
+        >
+          <td class="px-3 py-2 whitespace-nowrap tabular-nums">{{ formatDate(prestation.date) }}</td>
+          <td class="px-3 py-2 text-gray-400">{{ prestation.horaires || '—' }}</td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(prestation.heures) }}</td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(prestation.taux_horaire.taux) }}</td>
+          <td class="px-3 py-2 text-right tabular-nums font-medium text-white">
+            {{ formatEuros(prestation.heures * prestation.taux_horaire.taux) }}
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr class="border-t border-gray-700 font-semibold text-white">
+          <td class="px-3 py-2" colspan="2">
+            {{ prestations.length }} prestation{{ prestations.length > 1 ? 's' : '' }}
+          </td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(totalHeures) }}</td>
+          <td class="px-3 py-2"></td>
+          <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(totalMontant) }}</td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { formatDate, formatNombre, formatEuros } from '@/utils';
+
+const props = defineProps({
+  prestations: {
+    type: Array,
+    required: true,
+  },
+});
+
+const totalHeures = computed(() =>
+  props.prestations.reduce((acc, p) => acc + parseFloat(p.heures), 0)
+);
+
+const totalMontant = computed(() =>
+  props.prestations.reduce((acc, p) => acc + parseFloat(p.heures) * parseFloat(p.taux_horaire.taux), 0)
+);
+</script>

--- a/resources/js/components/factures/FacturePrestationsTable.vue
+++ b/resources/js/components/factures/FacturePrestationsTable.vue
@@ -1,41 +1,49 @@
 <template>
-  <div class="overflow-x-auto rounded-lg bg-gray-950/60 ring-1 ring-gray-700">
-    <table class="w-full text-sm">
-      <thead>
-        <tr class="text-left text-xs uppercase tracking-wide text-gray-400">
-          <th class="px-3 py-2 font-medium">Date</th>
-          <th class="px-3 py-2 font-medium">Horaires</th>
-          <th class="px-3 py-2 font-medium text-right">Heures</th>
-          <th class="px-3 py-2 font-medium text-right">Taux</th>
-          <th class="px-3 py-2 font-medium text-right">Total</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          v-for="prestation in prestations"
-          :key="prestation.id"
-          class="border-t border-gray-800 text-gray-200"
-        >
-          <td class="px-3 py-2 whitespace-nowrap tabular-nums">{{ formatDate(prestation.date) }}</td>
-          <td class="px-3 py-2 text-gray-400">{{ prestation.horaires || '—' }}</td>
-          <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(prestation.heures) }}</td>
-          <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(prestation.taux_horaire.taux) }}</td>
-          <td class="px-3 py-2 text-right tabular-nums font-medium text-white">
-            {{ formatEuros(prestation.heures * prestation.taux_horaire.taux) }}
-          </td>
-        </tr>
-      </tbody>
-      <tfoot>
-        <tr class="border-t border-gray-700 font-semibold text-white">
-          <td class="px-3 py-2" colspan="2">
-            {{ prestations.length }} prestation{{ prestations.length > 1 ? 's' : '' }}
-          </td>
-          <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(totalHeures) }}</td>
-          <td class="px-3 py-2"></td>
-          <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(totalMontant) }}</td>
-        </tr>
-      </tfoot>
-    </table>
+  <div>
+    <p v-if="invoice.paye_le" class="px-1 pb-2 text-sm text-emerald-400">
+      Payée le {{ invoice.paye_le }}
+    </p>
+
+    <div class="overflow-x-auto rounded-lg bg-gray-950/60 ring-1 ring-gray-700">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="text-left text-xs uppercase tracking-wide text-gray-400">
+            <th class="px-3 py-2 font-medium">Date</th>
+            <th class="px-3 py-2 font-medium">Horaires</th>
+            <th class="px-3 py-2 font-medium text-right">Heures</th>
+            <th class="px-3 py-2 font-medium text-right">Taux</th>
+            <th class="px-3 py-2 font-medium text-right">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="prestation in prestations"
+            :key="prestation.id"
+            class="border-t border-gray-800 text-gray-200"
+          >
+            <td class="px-3 py-2 whitespace-nowrap tabular-nums">{{ formatDate(prestation.date) }}</td>
+            <td class="px-3 py-2 text-gray-400">{{ prestation.horaires || '—' }}</td>
+            <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(prestation.heures) }}</td>
+            <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(prestation.taux_horaire.taux) }}</td>
+            <td class="px-3 py-2 text-right tabular-nums font-medium text-white">
+              {{ formatEuros(prestation.heures * prestation.taux_horaire.taux) }}
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr class="border-t border-gray-700 font-semibold text-white">
+            <td class="px-3 py-2" colspan="2">
+              {{ prestations.length }} prestation{{ prestations.length > 1 ? 's' : '' }}
+            </td>
+            <!-- Totaux issus du backend (figés à la création de la facture), pas recalculés :
+                 le taux horaire peut avoir changé depuis, la ligne repliée affiche ces mêmes valeurs. -->
+            <td class="px-3 py-2 text-right tabular-nums">{{ formatNombre(invoice.heures_total) }}</td>
+            <td class="px-3 py-2"></td>
+            <td class="px-3 py-2 text-right tabular-nums">{{ formatEuros(invoice.montant_total) }}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
   </div>
 </template>
 
@@ -44,17 +52,11 @@ import { computed } from 'vue';
 import { formatDate, formatNombre, formatEuros } from '@/utils';
 
 const props = defineProps({
-  prestations: {
-    type: Array,
+  invoice: {
+    type: Object,
     required: true,
   },
 });
 
-const totalHeures = computed(() =>
-  props.prestations.reduce((acc, p) => acc + parseFloat(p.heures), 0)
-);
-
-const totalMontant = computed(() =>
-  props.prestations.reduce((acc, p) => acc + parseFloat(p.heures) * parseFloat(p.taux_horaire.taux), 0)
-);
+const prestations = computed(() => props.invoice.prestations ?? []);
 </script>

--- a/resources/js/components/factures/FacturesList.vue
+++ b/resources/js/components/factures/FacturesList.vue
@@ -38,13 +38,13 @@
     <!-- La liste -->
     <div v-else class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 overflow-hidden">
       <!-- En-tête de colonnes : masqué sur mobile, où chaque ligne devient une carte -->
-      <div class="hidden sm:flex items-center px-4 py-2 border-b border-gray-700 text-xs uppercase tracking-wide text-gray-400">
+      <div class="hidden lg:flex items-center px-4 py-2 border-b border-gray-700 text-xs uppercase tracking-wide text-gray-400">
         <span class="w-[100px] shrink-0">N°</span>
         <span class="flex-1">Client</span>
         <span class="w-[100px] text-right">Heures</span>
         <span class="w-[130px] text-right">Montant</span>
-        <span class="w-[160px] pl-4">Statut</span>
-        <span class="w-[200px]"></span>
+        <span class="w-[180px] pl-4">Statut</span>
+        <span class="w-[240px]"></span>
       </div>
 
       <FactureListItem

--- a/resources/js/components/factures/FacturesList.vue
+++ b/resources/js/components/factures/FacturesList.vue
@@ -1,43 +1,82 @@
 <template>
-    <div class="mt-6">
-      <!-- 🎯 Filtres -->
-      <!-- <FactureFilters /> -->
-  
-      <!-- 🔄 Chargement -->
-      <div v-if="loading.fetch" class="flex justify-center my-6">
-        <div class="animate-spin inline-block w-6 h-6 border-4 border-white border-t-transparent rounded-full"></div>
-        <p class="text-white text-lg font-medium ml-2">Chargement des factures...</p>
-      </div>
-  
-      <!-- ❌ Erreur -->
-      <div v-else-if="errors.fetch" class="flex justify-center my-6 bg-red-500 text-white px-6 py-3 rounded-lg shadow-lg">
-        <span class="text-xl">❌</span>
-        <p class="text-lg font-medium ml-2">{{ errors.fetch }}</p>
-      </div>
-  
-      <!-- 📭 Aucune facture trouvée -->
-      <div v-else-if="invoices.length === 0" class="flex justify-center my-6 bg-gray-800 px-6 py-4 rounded-lg shadow-lg">
-        <p class="text-gray-300 text-lg">📭 Aucune facture trouvée.</p>
-      </div>
-  
-      <!-- ✅ Liste des factures -->
-      <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
-        <FactureListItem v-for="invoice in invoices" :invoice="invoice" :key="invoice.id" />
+  <div class="mt-6">
+    <FactureFilters />
+
+    <!-- Chargement : des lignes fantômes, pas un spinner, pour que la page ne saute pas -->
+    <div v-if="loading.fetch" class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 overflow-hidden">
+      <div v-for="n in 3" :key="n" class="flex items-center gap-4 px-4 py-4 border-b border-gray-700 last:border-b-0">
+        <div class="h-4 w-12 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-4 flex-1 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-4 w-20 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-4 w-24 bg-gray-700 rounded animate-pulse"></div>
+        <div class="h-6 w-28 bg-gray-700 rounded-full animate-pulse"></div>
       </div>
     </div>
-  </template>
-  
-  <script setup>
-  import { useInvoicesStore } from "@/stores/factures";
-  import { storeToRefs } from "pinia";
-  import { onMounted } from "vue";
-  import { FactureListItem } from "@/components/factures/";
-  
-  const invoicesStore = useInvoicesStore();
-  const { fetchInvoices } = invoicesStore;
-  const { invoices, errors, loading } = storeToRefs(invoicesStore);
-  
-  onMounted(() => {
-    fetchInvoices();
+
+    <!-- Erreur -->
+    <div v-else-if="errors.fetch" class="mt-6 flex justify-center bg-red-500 text-white px-6 py-3 rounded-lg shadow-lg">
+      <span class="text-xl">❌</span>
+      <p class="text-lg font-medium ml-2">{{ errors.fetch }}</p>
+    </div>
+
+    <!-- Aucune facture du tout -->
+    <div v-else-if="invoices.length === 0" class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 px-6 py-12 text-center">
+      <p class="text-3xl mb-2">📭</p>
+      <p class="text-white font-semibold mb-1">Aucune facture</p>
+      <p class="text-gray-400 mb-5">Créez votre première facture à partir de prestations non facturées.</p>
+      <button @click="emit('create')" class="btn-primary">Ajouter une facture</button>
+    </div>
+
+    <!-- Aucun résultat pour les filtres actifs : message distinct du précédent -->
+    <div v-else-if="filteredInvoices.length === 0" class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 px-6 py-12 text-center">
+      <p class="text-3xl mb-2">🔍</p>
+      <p class="text-white font-semibold mb-1">Aucun résultat</p>
+      <p class="text-gray-400 mb-5">Aucune facture ne correspond à ces filtres.</p>
+      <button @click="resetFilters" class="btn-secondary">Réinitialiser les filtres</button>
+    </div>
+
+    <!-- La liste -->
+    <div v-else class="mt-6 bg-gray-800 rounded-lg ring-1 ring-gray-700 overflow-hidden">
+      <!-- En-tête de colonnes : masqué sur mobile, où chaque ligne devient une carte -->
+      <div class="hidden sm:flex items-center px-4 py-2 border-b border-gray-700 text-xs uppercase tracking-wide text-gray-400">
+        <span class="w-[100px] shrink-0">N°</span>
+        <span class="flex-1">Client</span>
+        <span class="w-[100px] text-right">Heures</span>
+        <span class="w-[130px] text-right">Montant</span>
+        <span class="w-[160px] pl-4">Statut</span>
+        <span class="w-[200px]"></span>
+      </div>
+
+      <FactureListItem
+        v-for="invoice in filteredInvoices"
+        :key="invoice.id"
+        :invoice="invoice"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useInvoicesStore } from '@/stores/factures';
+import { FactureListItem, FactureFilters } from '@/components/factures/';
+
+const emit = defineEmits(['create']);
+
+const invoicesStore = useInvoicesStore();
+const { fetchInvoices, updateFilters } = invoicesStore;
+const { invoices, filteredInvoices, errors, loading } = storeToRefs(invoicesStore);
+
+onMounted(() => {
+  fetchInvoices();
+});
+
+const resetFilters = () => {
+  updateFilters({
+    statut: '',
+    client_id: '',
+    month_year: '',
   });
-  </script>
+};
+</script>

--- a/resources/js/components/factures/index.js
+++ b/resources/js/components/factures/index.js
@@ -5,6 +5,7 @@ import FacturePdfModal from './FacturePdfModal.vue';
 import FactureFormModal from './FactureFormModal.vue';
 import FactureMailModal from './FactureMailModal.vue';
 import FacturePrestationsTable from './FacturePrestationsTable.vue';
+import FactureFilters from './FactureFilters.vue';
 
 export {
     FacturesList,
@@ -14,4 +15,5 @@ export {
     FactureFormModal,
     FactureMailModal,
     FacturePrestationsTable,
+    FactureFilters,
 };

--- a/resources/js/components/factures/index.js
+++ b/resources/js/components/factures/index.js
@@ -4,6 +4,7 @@ import FactureDeleteModal from './FactureDeleteModal.vue';
 import FacturePdfModal from './FacturePdfModal.vue';
 import FactureFormModal from './FactureFormModal.vue';
 import FactureMailModal from './FactureMailModal.vue';
+import FacturePrestationsTable from './FacturePrestationsTable.vue';
 
 export {
     FacturesList,
@@ -12,4 +13,5 @@ export {
     FacturePdfModal,
     FactureFormModal,
     FactureMailModal,
+    FacturePrestationsTable,
 };

--- a/resources/js/stores/factures.js
+++ b/resources/js/stores/factures.js
@@ -1,6 +1,6 @@
 // src/stores/invoices.js
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { ref, computed, watch } from 'vue';
 import axios from 'axios';
 import { notify } from '@/utils';
 import { useDashboardStore } from "@/stores/dashboard";
@@ -10,6 +10,43 @@ export const useInvoicesStore = defineStore('invoices', () => {
   const invoices = ref([]);
   const errors = ref({});
   const loading = ref({});
+
+  // Filtres de la liste des factures (appliqués côté client)
+  const activeFilters = ref({
+    statut: '',
+    client_id: '',
+    month_year: '',
+  });
+
+  function updateFilters(filters) {
+    activeFilters.value = filters;
+  }
+
+  const isAnyFilterActive = computed(() => {
+    return Object.values(activeFilters.value).some(value => value !== "");
+  });
+
+  // Factures filtrées, les plus récentes en tête.
+  // Le tri se fait sur l'id : created_at arrive au format d/m/Y H:i:s,
+  // que JavaScript ne sait pas trier.
+  const filteredInvoices = ref([]);
+  watch([invoices, activeFilters], () => {
+    filteredInvoices.value = invoices.value
+      .filter(invoice => {
+        const { statut, client_id, month_year } = activeFilters.value;
+
+        if (statut && invoice.statut !== statut) return false;
+
+        if (client_id && invoice.prestations?.[0]?.client_id !== client_id) return false;
+
+        // La facture est retenue si au moins une de ses prestations
+        // tombe dans le mois demandé. prestation.date est au format Y-m-d.
+        if (month_year && !invoice.prestations?.some(p => p.date?.startsWith(month_year))) return false;
+
+        return true;
+      })
+      .sort((a, b) => b.id - a.id);
+  }, { deep: true, immediate: true });
 
   const dashboardStore = useDashboardStore();
 
@@ -163,13 +200,17 @@ export const useInvoicesStore = defineStore('invoices', () => {
   }
 
 
-  return { 
-    invoices, 
-    errors, 
-    loading, 
+  return {
+    invoices,
+    filteredInvoices,
+    activeFilters,
+    updateFilters,
+    isAnyFilterActive,
+    errors,
+    loading,
     fetchInvoices,
-    addInvoice, 
-    deleteInvoice, 
+    addInvoice,
+    deleteInvoice,
     clearErrors,
     getInvoicePdf,
     paid,

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -23,3 +23,17 @@ export function validateEmail(email) {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
 }
+
+export function formatNombre(valeur) {
+  return new Intl.NumberFormat('fr-FR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(valeur);
+}
+
+export function formatEuros(valeur) {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(valeur);
+}

--- a/resources/js/views/Facture.vue
+++ b/resources/js/views/Facture.vue
@@ -15,7 +15,7 @@
               </div>
             </div>
             <!-- 📋 Liste des factures -->
-            <FacturesList />
+            <FacturesList @create="showFormModal = true" />
             <FactureFormModal v-if="showFormModal" @close="showFormModal = false" />
           </div>
         </div>


### PR DESCRIPTION
L'onglet Factures affichait chaque facture en carte, en déroulant **toutes** ses prestations. La facture de juin (25 prestations) occupait à elle seule plusieurs écrans de haut — et comme les cartes d'une même ligne de grille s'alignent sur la plus haute, une seule facture volumineuse déformait toute la liste.

Elle devient une **liste dense** : une facture par ligne (n°, client, heures, montant, statut, actions), dont les prestations se **déplient** en tableau reprenant les colonnes du PDF.

## Ce que ça change

| Couche | Changement |
|---|---|
| Store | Filtres côté client (statut, client, mois) + tri, sur le modèle du store des prestations |
| `FactureFilters` (créé) | Statut, client, mois des prestations, réinitialisation |
| `FactureListItem` (récrit) | Une ligne dépliable au lieu d'une carte |
| `FacturePrestationsTable` (créé) | Le tableau du détail déplié |
| `FacturesList` (récrit) | En-tête de colonnes + quatre états distincts |

Le filtre par mois porte sur la **date des prestations**, pas sur la création de la facture : « juin » remonte la facture de juin même si elle a été émise le 1er juillet.

Quatre états couverts, dont deux qu'on confond souvent : « aucune facture » (avec bouton de création) et « aucun résultat pour ces filtres » (avec réinitialisation). Aucun changement backend.

## Ce que la revue a rattrapé

**Une régression** : la date de paiement (`paye_le`) avait disparu du produit — l'ancienne carte l'affichait, la nouvelle ligne non, et elle n'apparaît nulle part ailleurs (pas même dans le PDF). Elle est réaffichée dans le tableau déplié.

**Une contradiction de montants** : le pied du tableau recalculait les totaux en JS, alors que `montant_total` est figé en base à la création et que le taux horaire reste modifiable ensuite. Un taux modifié après facturation aurait affiché deux montants différents pour la même facture. Le pied affiche désormais les valeurs du backend.

**Le responsive** : les colonnes ont été mesurées dans un navigateur à huit largeurs d'écran. Le layout tabulaire démarrait à 640 px alors que les colonnes fixes en réclament 690 — le nom du client disparaissait entre 640 et 745 px, et les boutons d'action repeignaient par-dessus le badge de statut. Le layout en colonnes démarre maintenant à 1024 px, avec des colonnes dimensionnées d'après les mesures réelles.

Au passage, la refonte **corrige un crash** : l'ancien code accédait à `invoice.prestations[0].client.nom` sans garde, ce qui faisait planter le rendu de toute la liste sur une facture sans prestation.

## Vérifications

- `npm run build` : vert.
- `php artisan test --testsuite=Feature` : **68 tests, 214 assertions**, verts (la branche ne touche pas au backend).
- Rendu mesuré en navigateur headless à 676 / 800 / 1024 / 1280 / 1576 px : aucun chevauchement, en-tête et cellules alignés au pixel.

## Dettes ouvertes (hors périmètre)

- **Le taux horaire n'est pas figé à la facturation** : c'est une clé étrangère vivante, donc une facture émise peut voir ses lignes changer de montant si on modifie le taux. Le PDF a exactement le même défaut. C'est la vraie correction de fond, elle mérite sa propre PR.
- `loading.paid` est un état global du store : marquer une facture payée fait clignoter le bouton de toutes les lignes en attente. Préexistant, mais plus visible sur une liste dense.

Spec et plan : `docs/superpowers/specs/2026-07-12-refonte-onglet-factures-design.md`, `docs/superpowers/plans/2026-07-12-refonte-onglet-factures.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj