### PR TITLE
Sécurité : faille IDOR sur les taux horaires + suppressions non destructrices

### DIFF
--- a/app/Actions/DeleteUser.php
+++ b/app/Actions/DeleteUser.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class DeleteUser
+{
+    /**
+     * Point d'entrée UNIQUE pour supprimer un compte utilisateur.
+     *
+     * Ne jamais supprimer un `User` autrement (ni `$user->delete()` isolé, ni
+     * `User::where(...)->delete()`, ni tout autre delete de query builder) :
+     *
+     * - `UserObserver::deleting()` vide d'abord les prestations de
+     *   l'utilisateur, faute de quoi la cascade native de la base peut
+     *   tenter de supprimer un client ou un taux horaire avant la prestation
+     *   qui le référence encore (RESTRICT) et échouer sur MySQL/InnoDB
+     *   (SQLSTATE 23000 / erreur 1451) — invisible sur SQLite. Or les
+     *   événements Eloquent (`deleting`, donc l'observer) ne se déclenchent
+     *   que sur `Model::delete()` / `Model::destroy()`, jamais sur un
+     *   `delete()` de query builder.
+     * - `Model::delete()` ne s'exécute lui-même dans aucune transaction :
+     *   l'event `deleting` part, PUIS le `DELETE` s'exécute. Sans la
+     *   transaction ouverte ici, un échec de la suppression du `User` après
+     *   coup (veto d'un autre listener, exception, deadlock…) laisserait les
+     *   prestations déjà détruites par l'observer alors que le compte, lui,
+     *   existe toujours. Cette action rend l'ensemble atomique : soit tout
+     *   est supprimé, soit rien ne l'est.
+     */
+    public function execute(User $user): void
+    {
+        DB::transaction(function () use ($user) {
+            $user->delete();
+        });
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,10 +3,13 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
+#[ObservedBy(UserObserver::class)]
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -3,7 +3,6 @@
 namespace App\Observers;
 
 use App\Models\User;
-use Illuminate\Support\Facades\DB;
 
 class UserObserver
 {
@@ -31,11 +30,19 @@ class UserObserver
      * native sur clients, taux_horaires, factures puis users peut ensuite
      * s'exécuter sans obstacle. prestations.facture_id est en
      * nullOnDelete et ne bloque de toute façon jamais une suppression.
+     *
+     * IMPORTANT : cette méthode n'ouvre volontairement AUCUNE transaction.
+     * `Model::delete()` ne s'exécute pas lui-même dans une transaction : il
+     * déclenche l'event `deleting` (donc cette méthode), PUIS exécute le
+     * `DELETE` du user. Une transaction ouverte ici committerait dès la fin
+     * de cette méthode, indépendamment du succès de la suppression du user
+     * qui suit — les prestations seraient perdues même si la suppression du
+     * user échoue ensuite. L'atomicité est garantie par l'appelant : voir
+     * `App\Actions\DeleteUser`, le seul point d'entrée à utiliser pour
+     * supprimer un compte.
      */
     public function deleting(User $user): void
     {
-        DB::transaction(function () use ($user) {
-            $user->prestations()->delete();
-        });
+        $user->prestations()->delete();
     }
 }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class UserObserver
+{
+    /**
+     * Supprime explicitement les prestations de l'utilisateur avant que la
+     * cascade native de la base ne s'attaque à ses clients, taux horaires
+     * et factures.
+     *
+     * Depuis la migration 2026_07_12_134733, prestations.client_id et
+     * prestations.taux_horaire_id sont en RESTRICT (défense en profondeur
+     * contre les suppressions de client/taux horaire encore utilisés).
+     * Mais users.id reste référencé en CASCADE direct par clients.user_id,
+     * taux_horaires.user_id, factures.user_id ET prestations.user_id.
+     *
+     * Sans cette étape, `DELETE FROM users WHERE id = ?` déclenche des
+     * cascades concurrentes vers clients/taux_horaires (CASCADE) et vers
+     * prestations (CASCADE) : si InnoDB traite un client ou un taux
+     * horaire avant la prestation qui le référence encore, la contrainte
+     * RESTRICT de prestations bloque toute l'opération (SQLSTATE 23000 /
+     * erreur 1451) — reproduit sur MySQL, invisible sur SQLite où l'ordre
+     * de résolution diffère.
+     *
+     * En vidant d'abord prestations pour cet utilisateur, plus aucune
+     * ligne ne référence ses clients ou ses taux horaires : la cascade
+     * native sur clients, taux_horaires, factures puis users peut ensuite
+     * s'exécuter sans obstacle. prestations.facture_id est en
+     * nullOnDelete et ne bloque de toute façon jamais une suppression.
+     */
+    public function deleting(User $user): void
+    {
+        DB::transaction(function () use ($user) {
+            $user->prestations()->delete();
+        });
+    }
+}

--- a/app/Policies/ClientPolicy.php
+++ b/app/Policies/ClientPolicy.php
@@ -29,15 +29,35 @@ class ClientPolicy
             return false;
         }
 
-        $nombre = $client->prestations()->count();
+        $nonFacturees = $client->prestations()->whereNull('facture_id')->count();
+        $facturees = $client->prestations()->whereNotNull('facture_id')->count();
 
-        if ($nombre > 0) {
+        if ($nonFacturees === 0 && $facturees === 0) {
+            return true;
+        }
+
+        if ($facturees === 0) {
             return Response::deny(
-                "Ce client a {$nombre} prestation" . ($nombre > 1 ? 's' : '') . '. '
-                . 'Supprimez-les avant de supprimer le client.'
+                "Ce client a {$nonFacturees} prestation" . ($nonFacturees > 1 ? 's' : '') . ' non facturée'
+                . ($nonFacturees > 1 ? 's' : '') . '. '
+                . 'Supprimez-l' . ($nonFacturees > 1 ? 'es' : 'a') . ' avant de supprimer le client.'
             );
         }
 
-        return true;
+        if ($nonFacturees === 0) {
+            return Response::deny(
+                "Ce client a {$facturees} prestation" . ($facturees > 1 ? 's' : '') . ' facturée'
+                . ($facturees > 1 ? 's' : '') . '. '
+                . 'Supprimez d\'abord la ou les factures correspondantes avant de supprimer le client.'
+            );
+        }
+
+        return Response::deny(
+            "Ce client a {$nonFacturees} prestation" . ($nonFacturees > 1 ? 's' : '') . ' non facturée'
+            . ($nonFacturees > 1 ? 's' : '') . " et {$facturees} prestation" . ($facturees > 1 ? 's' : '')
+            . ' facturée' . ($facturees > 1 ? 's' : '') . '. '
+            . 'Supprimez d\'abord les prestations non facturées, ainsi que la ou les factures '
+            . 'correspondantes aux prestations facturées, avant de supprimer le client.'
+        );
     }
 }

--- a/app/Policies/ClientPolicy.php
+++ b/app/Policies/ClientPolicy.php
@@ -48,7 +48,8 @@ class ClientPolicy
             return Response::deny(
                 "Ce client a {$facturees} prestation" . ($facturees > 1 ? 's' : '') . ' facturée'
                 . ($facturees > 1 ? 's' : '') . '. '
-                . 'Supprimez d\'abord la ou les factures correspondantes avant de supprimer le client.'
+                . 'Supprimez d\'abord la ou les factures correspondantes, puis supprimez la ou les '
+                . 'prestations ainsi détachées, avant de supprimer le client.'
             );
         }
 
@@ -56,8 +57,9 @@ class ClientPolicy
             "Ce client a {$nonFacturees} prestation" . ($nonFacturees > 1 ? 's' : '') . ' non facturée'
             . ($nonFacturees > 1 ? 's' : '') . " et {$facturees} prestation" . ($facturees > 1 ? 's' : '')
             . ' facturée' . ($facturees > 1 ? 's' : '') . '. '
-            . 'Supprimez d\'abord les prestations non facturées, ainsi que la ou les factures '
-            . 'correspondantes aux prestations facturées, avant de supprimer le client.'
+            . 'Supprimez d\'abord la ou les prestations non facturées, puis supprimez la ou les factures '
+            . 'correspondant aux prestations facturées ainsi que la ou les prestations ainsi détachées, '
+            . 'avant de supprimer le client.'
         );
     }
 }

--- a/app/Policies/ClientPolicy.php
+++ b/app/Policies/ClientPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\Client;
 use App\Models\User;
+use Illuminate\Auth\Access\Response;
 
 class ClientPolicy
 {
@@ -16,10 +17,27 @@ class ClientPolicy
     }
 
     /**
-     * L'utilisateur peut supprimer un client **s'il en est le propriétaire**.
+     * L'utilisateur peut supprimer un client **s'il en est le propriétaire**
+     * et **si aucune prestation ne lui est rattachée**.
+     *
+     * Sans ce garde-fou, la cascade de la base détruirait ses prestations —
+     * y compris facturées, laissant des factures sans lignes dont le PDF échoue.
      */
-    public function delete(User $user, Client $client): bool
+    public function delete(User $user, Client $client): Response|bool
     {
-        return $user->id === $client->user_id;
+        if ($user->id !== $client->user_id) {
+            return false;
+        }
+
+        $nombre = $client->prestations()->count();
+
+        if ($nombre > 0) {
+            return Response::deny(
+                "Ce client a {$nombre} prestation" . ($nombre > 1 ? 's' : '') . '. '
+                . 'Supprimez-les avant de supprimer le client.'
+            );
+        }
+
+        return true;
     }
 }

--- a/app/Policies/TauxHorairePolicy.php
+++ b/app/Policies/TauxHorairePolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\TauxHoraire;
 use App\Models\User;
+use Illuminate\Auth\Access\Response;
 
 class TauxHorairePolicy
 {
@@ -23,15 +24,29 @@ class TauxHorairePolicy
 
     /**
      * L'utilisateur peut supprimer un taux horaire **s'il en est le propriétaire**
-     * et **tant qu'aucune facture ne s'appuie dessus**.
+     * et **si aucune prestation ne l'utilise** — facturée ou non.
+     *
+     * Sans ce garde-fou, la cascade de la base détruirait silencieusement les
+     * prestations non facturées qui s'appuient sur ce taux.
      */
-    public function delete(User $user, TauxHoraire $tauxHoraire): bool
+    public function delete(User $user, TauxHoraire $tauxHoraire): Response|bool
     {
+        // La propriété d'abord : le message de refus ci-dessous ne doit jamais
+        // renseigner un intrus sur le volume d'activité d'autrui.
         if ($user->id !== $tauxHoraire->user_id) {
             return false;
         }
 
-        return !$tauxHoraire->prestations()->whereNotNull('facture_id')->exists();
+        $nombre = $tauxHoraire->prestations()->count();
+
+        if ($nombre > 0) {
+            return Response::deny(
+                "Ce taux horaire est utilisé par {$nombre} prestation" . ($nombre > 1 ? 's' : '') . '. '
+                . 'Modifiez leur taux ou supprimez-les avant de le supprimer.'
+            );
+        }
+
+        return true;
     }
 }
 

--- a/app/Policies/TauxHorairePolicy.php
+++ b/app/Policies/TauxHorairePolicy.php
@@ -7,13 +7,30 @@ use App\Models\User;
 
 class TauxHorairePolicy
 {
+    /**
+     * L'utilisateur peut modifier un taux horaire **s'il en est le propriétaire**
+     * et **tant qu'aucune facture ne s'appuie dessus** — sinon les lignes d'une
+     * facture émise changeraient rétroactivement.
+     */
     public function update(User $user, TauxHoraire $tauxHoraire): bool
     {
+        if ($user->id !== $tauxHoraire->user_id) {
+            return false;
+        }
+
         return !$tauxHoraire->prestations()->whereNotNull('facture_id')->exists();
     }
 
+    /**
+     * L'utilisateur peut supprimer un taux horaire **s'il en est le propriétaire**
+     * et **tant qu'aucune facture ne s'appuie dessus**.
+     */
     public function delete(User $user, TauxHoraire $tauxHoraire): bool
     {
+        if ($user->id !== $tauxHoraire->user_id) {
+            return false;
+        }
+
         return !$tauxHoraire->prestations()->whereNotNull('facture_id')->exists();
     }
 }

--- a/app/Policies/TauxHorairePolicy.php
+++ b/app/Policies/TauxHorairePolicy.php
@@ -70,7 +70,8 @@ class TauxHorairePolicy
             return Response::deny(
                 "Ce taux horaire est utilisé par {$facturees} prestation" . ($facturees > 1 ? 's' : '')
                 . ' facturée' . ($facturees > 1 ? 's' : '') . '. '
-                . 'Supprimez d\'abord la ou les factures correspondantes avant de supprimer ce taux horaire.'
+                . 'Supprimez d\'abord la ou les factures correspondantes, puis modifiez le taux de la ou '
+                . 'des prestations ainsi détachées ou supprimez-les, avant de supprimer ce taux horaire.'
             );
         }
 
@@ -78,8 +79,9 @@ class TauxHorairePolicy
             "Ce taux horaire est utilisé par {$nonFacturees} prestation" . ($nonFacturees > 1 ? 's' : '')
             . ' non facturée' . ($nonFacturees > 1 ? 's' : '') . " et {$facturees} prestation"
             . ($facturees > 1 ? 's' : '') . ' facturée' . ($facturees > 1 ? 's' : '') . '. '
-            . 'Modifiez le taux des prestations non facturées ou supprimez-les, et supprimez d\'abord '
-            . 'la ou les factures correspondantes aux prestations facturées, avant de supprimer ce taux horaire.'
+            . 'Modifiez le taux de la ou des prestations non facturées ou supprimez-les, puis supprimez '
+            . 'la ou les factures correspondant aux prestations facturées ainsi que la ou les prestations '
+            . 'ainsi détachées, avant de supprimer ce taux horaire.'
         );
     }
 }

--- a/app/Policies/TauxHorairePolicy.php
+++ b/app/Policies/TauxHorairePolicy.php
@@ -13,13 +13,24 @@ class TauxHorairePolicy
      * et **tant qu'aucune facture ne s'appuie dessus** — sinon les lignes d'une
      * facture émise changeraient rétroactivement.
      */
-    public function update(User $user, TauxHoraire $tauxHoraire): bool
+    public function update(User $user, TauxHoraire $tauxHoraire): Response|bool
     {
+        // La propriété d'abord, et en `false` muet : le message de refus
+        // ci-dessous ne doit jamais renseigner un intrus sur l'usage que le
+        // propriétaire fait de ce taux horaire.
         if ($user->id !== $tauxHoraire->user_id) {
             return false;
         }
 
-        return !$tauxHoraire->prestations()->whereNotNull('facture_id')->exists();
+        if ($tauxHoraire->prestations()->whereNotNull('facture_id')->exists()) {
+            return Response::deny(
+                'Ce taux horaire est utilisé par au moins une prestation facturée : ses valeurs ne '
+                . 'peuvent plus être modifiées, cela changerait rétroactivement une facture déjà émise. '
+                . 'Supprimez d\'abord la ou les factures correspondantes si vous devez le modifier.'
+            );
+        }
+
+        return true;
     }
 
     /**
@@ -37,16 +48,39 @@ class TauxHorairePolicy
             return false;
         }
 
-        $nombre = $tauxHoraire->prestations()->count();
+        $nonFacturees = $tauxHoraire->prestations()->whereNull('facture_id')->count();
+        $facturees = $tauxHoraire->prestations()->whereNotNull('facture_id')->count();
 
-        if ($nombre > 0) {
+        if ($nonFacturees === 0 && $facturees === 0) {
+            return true;
+        }
+
+        if ($facturees === 0) {
+            $leurTaux = $nonFacturees > 1 ? 'leur taux' : 'son taux';
+
             return Response::deny(
-                "Ce taux horaire est utilisé par {$nombre} prestation" . ($nombre > 1 ? 's' : '') . '. '
-                . 'Modifiez leur taux ou supprimez-les avant de le supprimer.'
+                "Ce taux horaire est utilisé par {$nonFacturees} prestation" . ($nonFacturees > 1 ? 's' : '')
+                . ' non facturée' . ($nonFacturees > 1 ? 's' : '') . '. '
+                . "Modifiez {$leurTaux} ou supprimez-l" . ($nonFacturees > 1 ? 'es' : 'a')
+                . ' avant de supprimer ce taux horaire.'
             );
         }
 
-        return true;
+        if ($nonFacturees === 0) {
+            return Response::deny(
+                "Ce taux horaire est utilisé par {$facturees} prestation" . ($facturees > 1 ? 's' : '')
+                . ' facturée' . ($facturees > 1 ? 's' : '') . '. '
+                . 'Supprimez d\'abord la ou les factures correspondantes avant de supprimer ce taux horaire.'
+            );
+        }
+
+        return Response::deny(
+            "Ce taux horaire est utilisé par {$nonFacturees} prestation" . ($nonFacturees > 1 ? 's' : '')
+            . ' non facturée' . ($nonFacturees > 1 ? 's' : '') . " et {$facturees} prestation"
+            . ($facturees > 1 ? 's' : '') . ' facturée' . ($facturees > 1 ? 's' : '') . '. '
+            . 'Modifiez le taux des prestations non facturées ou supprimez-les, et supprimez d\'abord '
+            . 'la ou les factures correspondantes aux prestations facturées, avant de supprimer ce taux horaire.'
+        );
     }
 }
 

--- a/database/migrations/2026_07_12_134733_restreint_suppression_prestations.php
+++ b/database/migrations/2026_07_12_134733_restreint_suppression_prestations.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Empêche la base de détruire des prestations en cascade.
+     *
+     * `client_id` et `taux_horaire_id` étaient en CASCADE : supprimer un client
+     * ou un taux horaire détruisait silencieusement ses prestations — y compris
+     * facturées. Les policies refusent désormais ces suppressions ; la base doit
+     * refuser aussi, pour tout ce qui ne passe pas par elles (commandes artisan,
+     * seeders, futurs endpoints).
+     *
+     * `user_id` reste en CASCADE : supprimer un compte doit bien tout emporter.
+     */
+    public function up(): void
+    {
+        Schema::table('prestations', function (Blueprint $table) {
+            $table->dropForeign(['client_id']);
+            $table->foreign('client_id')->references('id')->on('clients')->restrictOnDelete();
+
+            $table->dropForeign(['taux_horaire_id']);
+            $table->foreign('taux_horaire_id')->references('id')->on('taux_horaires')->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('prestations', function (Blueprint $table) {
+            $table->dropForeign(['client_id']);
+            $table->foreign('client_id')->references('id')->on('clients')->cascadeOnDelete();
+
+            $table->dropForeign(['taux_horaire_id']);
+            $table->foreign('taux_horaire_id')->references('id')->on('taux_horaires')->cascadeOnDelete();
+        });
+    }
+};

--- a/docs/superpowers/plans/2026-07-12-securite-taux-horaires-et-suppressions.md
+++ b/docs/superpowers/plans/2026-07-12-securite-taux-horaires-et-suppressions.md
@@ -1,0 +1,589 @@
+# Sécurité des taux horaires et suppressions non destructrices — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fermer la faille IDOR des taux horaires, et faire que supprimer un taux ou un client refuse au lieu de détruire les prestations en cascade.
+
+**Architecture :** Les policies gagnent la vérification de propriété qui manque et refusent la suppression d'une ressource encore utilisée, avec un message explicite. Une migration passe les clés étrangères de `prestations` en `restrictOnDelete` pour que la base refuse aussi, même si un jour du code contourne les policies.
+
+**Tech Stack :** Laravel 12.1.1 (PHP 8.4), Pest (`it()` + `RefreshDatabase`), SQLite en mémoire pour les tests, MySQL en production.
+
+## Global Constraints
+
+- Spec de référence : `docs/superpowers/specs/2026-07-12-securite-taux-horaires-et-suppressions-design.md`
+- **L'ordre des vérifications dans les policies est imposé : la propriété D'ABORD, l'usage ENSUITE.** Si la policy comptait les prestations avant de vérifier le propriétaire, son message de refus (« utilisé par 25 prestations ») révélerait à un intrus le volume d'activité d'autrui. Le refus pour cause de propriété est un `false` muet ; seul le refus pour cause d'usage porte un message (`Illuminate\Auth\Access\Response::deny(...)`).
+- `TauxHorairePolicy::update` continue d'autoriser la modification d'un taux dont les prestations ne sont **pas** facturées : ces prestations ne sont pas encore figées dans une facture, c'est légitime.
+- Une prestation **facturée** ne peut être ni modifiée ni supprimée : `PrestationPolicy` le fait déjà, ne pas y toucher.
+- `user_id` sur `prestations` **reste en cascade** : supprimer un compte doit tout emporter. Seuls `client_id` et `taux_horaire_id` passent en `restrictOnDelete`.
+- Les tests tournent en local, en SQLite en mémoire : `php artisan test --testsuite=Feature`. **Jamais `php artisan test` sans `--testsuite=Feature`** : `phpunit.xml` déclare une suite `Unit` alors que `tests/Unit/` n'existe pas (préexistant, hors périmètre). Point de départ : 68 tests verts.
+- Vérifié : Laravel 12.1.1 sait exécuter `dropForeign` sur SQLite (il recrée la table). La migration passe donc sur les deux moteurs.
+- Aucun changement front n'est nécessaire : le store relaie déjà le message d'erreur de l'API en toast (`apiCall` fait `notify('error', err.response.data.message)`). Vérifié dans `resources/js/stores/taux-horaires.js`.
+- Commits en français, format `type: description`.
+
+---
+
+### Task 1 : Fermer la faille IDOR sur les taux horaires
+
+C'est la correction de sécurité. Elle part seule : elle doit pouvoir être déployée sans attendre le reste.
+
+**Files:**
+- Modify: `app/Policies/TauxHorairePolicy.php`
+- Test: `tests/Feature/TauxHoraireSecurityTest.php`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: `TauxHorairePolicy::update()` et `::delete()` vérifient la propriété. La tâche 2 modifie le même fichier — elle s'appuie sur cette vérification, placée en premier.
+
+Le contexte : `TauxHorairePolicy` ne compare jamais `$user->id` à `$tauxHoraire->user_id`. Elle ne regarde que les prestations facturées. Un tiers peut donc modifier et supprimer le taux d'autrui (constaté : 200, taux passé de 60 à 1).
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/Feature/TauxHoraireSecurityTest.php` :
+
+```php
+<?php
+
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('interdit a un tiers de modifier le taux horaire d\'un autre utilisateur', function () {
+    $proprietaire = User::factory()->create();
+    $intrus       = User::factory()->create();
+
+    $taux = TauxHoraire::factory()->create([
+        'user_id' => $proprietaire->id,
+        'taux'    => 60,
+    ]);
+
+    $this->actingAs($intrus)
+        ->putJson("/api/taux-horaires/{$taux->id}", ['taux' => 1])
+        ->assertForbidden();
+
+    // Le taux ne doit pas avoir bougé.
+    expect((float) $taux->fresh()->taux)->toBe(60.0);
+});
+
+it('interdit a un tiers de supprimer le taux horaire d\'un autre utilisateur', function () {
+    $proprietaire = User::factory()->create();
+    $intrus       = User::factory()->create();
+
+    $taux = TauxHoraire::factory()->create(['user_id' => $proprietaire->id, 'taux' => 60]);
+
+    $this->actingAs($intrus)
+        ->deleteJson("/api/taux-horaires/{$taux->id}")
+        ->assertForbidden();
+
+    expect(TauxHoraire::find($taux->id))->not->toBeNull();
+});
+
+it('autorise le proprietaire a modifier son propre taux horaire non facture', function () {
+    $user = User::factory()->create();
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $this->actingAs($user)
+        ->putJson("/api/taux-horaires/{$taux->id}", ['taux' => 65])
+        ->assertOk();
+
+    expect((float) $taux->fresh()->taux)->toBe(65.0);
+});
+```
+
+> Note : le troisième test garantit qu'on ne casse pas le cas nominal en fermant la faille. Si `PUT /api/taux-horaires/{id}` exige d'autres champs que `taux` (regarde `app/Http/Requests/TauxHoraireRequest.php`), complète le corps de la requête — mais ne modifie pas la Form Request.
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/TauxHoraireSecurityTest.php`
+Expected: les deux premiers tests ÉCHOUENT (l'API renvoie 200 au lieu de 403 — c'est la faille). Le troisième passe déjà.
+
+- [ ] **Step 3: Fermer la faille**
+
+Remplacer `app/Policies/TauxHorairePolicy.php` par :
+
+```php
+<?php
+
+namespace App\Policies;
+
+use App\Models\TauxHoraire;
+use App\Models\User;
+
+class TauxHorairePolicy
+{
+    /**
+     * L'utilisateur peut modifier un taux horaire **s'il en est le propriétaire**
+     * et **tant qu'aucune facture ne s'appuie dessus** — sinon les lignes d'une
+     * facture émise changeraient rétroactivement.
+     */
+    public function update(User $user, TauxHoraire $tauxHoraire): bool
+    {
+        if ($user->id !== $tauxHoraire->user_id) {
+            return false;
+        }
+
+        return !$tauxHoraire->prestations()->whereNotNull('facture_id')->exists();
+    }
+
+    /**
+     * L'utilisateur peut supprimer un taux horaire **s'il en est le propriétaire**
+     * et **tant qu'aucune facture ne s'appuie dessus**.
+     */
+    public function delete(User $user, TauxHoraire $tauxHoraire): bool
+    {
+        if ($user->id !== $tauxHoraire->user_id) {
+            return false;
+        }
+
+        return !$tauxHoraire->prestations()->whereNotNull('facture_id')->exists();
+    }
+}
+```
+
+La vérification de propriété passe **en premier** : un intrus ne doit rien apprendre sur les données d'autrui, pas même par un message d'erreur.
+
+- [ ] **Step 4: Lancer les tests et vérifier qu'ils passent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/TauxHoraireSecurityTest.php`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Lancer la suite complète**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 71 tests (68 + 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Policies/TauxHorairePolicy.php tests/Feature/TauxHoraireSecurityTest.php
+git commit -m "fix: ferme la faille IDOR sur les taux horaires"
+```
+
+---
+
+### Task 2 : Refuser la suppression d'un taux ou d'un client encore utilisé
+
+**Files:**
+- Modify: `app/Policies/TauxHorairePolicy.php` (la méthode `delete`)
+- Modify: `app/Policies/ClientPolicy.php` (la méthode `delete`)
+- Test: `tests/Feature/SuppressionNonDestructiveTest.php`
+
+**Interfaces:**
+- Consumes: la vérification de propriété posée par la tâche 1 dans `TauxHorairePolicy`.
+- Produces: `delete()` renvoie désormais `Response|bool` (et non plus `bool`) sur les deux policies — un `Response::deny(message)` quand la ressource est encore utilisée.
+
+Le contexte : `prestations` déclare `onDelete('cascade')` sur `client_id` et `taux_horaire_id`. Aujourd'hui, supprimer un taux **jamais facturé** renvoie 200 et **détruit ses prestations non facturées** (constaté). Supprimer un client détruit **toutes** ses prestations, même facturées, laissant des factures sans lignes.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/Feature/SuppressionNonDestructiveTest.php` :
+
+```php
+<?php
+
+use App\Models\Client;
+use App\Models\Facture;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('refuse de supprimer un taux horaire utilise par des prestations non facturees, sans rien detruire', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,   // NON facturée
+    ]);
+
+    $response = $this->actingAs($user)->deleteJson("/api/taux-horaires/{$taux->id}");
+
+    $response->assertForbidden();
+
+    // Le cœur du test : la prestation ne doit PAS avoir été détruite en cascade.
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+    expect(TauxHoraire::find($taux->id))->not->toBeNull();
+});
+
+it('refuse de supprimer un taux horaire deja facture', function () {
+    $user    = User::factory()->create();
+    $client  = Client::factory()->create(['user_id' => $user->id]);
+    $taux    = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => $facture->id,
+    ]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/taux-horaires/{$taux->id}")
+        ->assertForbidden();
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+});
+
+it('autorise la suppression d\'un taux horaire sans aucune prestation', function () {
+    $user = User::factory()->create();
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/taux-horaires/{$taux->id}")
+        ->assertOk();
+
+    expect(TauxHoraire::find($taux->id))->toBeNull();
+});
+
+it('refuse de supprimer un client qui a des prestations, sans rien detruire', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/clients/{$client->id}")
+        ->assertForbidden();
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+    expect(Client::find($client->id))->not->toBeNull();
+});
+
+it('autorise la suppression d\'un client sans prestation', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/clients/{$client->id}")
+        ->assertOk();
+
+    expect(Client::find($client->id))->toBeNull();
+});
+
+it('explique pourquoi la suppression est refusee', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    Prestation::factory()->count(3)->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    $response = $this->actingAs($user)->deleteJson("/api/taux-horaires/{$taux->id}");
+
+    // Le message doit être exploitable : il dit combien de prestations bloquent.
+    expect($response->json('message'))->toContain('3 prestations');
+});
+
+it('ne revele rien a un intrus dans le message de refus', function () {
+    $proprietaire = User::factory()->create();
+    $intrus       = User::factory()->create();
+
+    $client = Client::factory()->create(['user_id' => $proprietaire->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $proprietaire->id, 'taux' => 60]);
+
+    Prestation::factory()->count(25)->create([
+        'user_id'         => $proprietaire->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    $response = $this->actingAs($intrus)->deleteJson("/api/taux-horaires/{$taux->id}");
+
+    $response->assertForbidden();
+
+    // Le refus ne doit PAS trahir le volume d'activité du propriétaire.
+    expect($response->json('message'))->not->toContain('25');
+});
+```
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/SuppressionNonDestructiveTest.php`
+Expected: FAIL. En particulier, « refuse de supprimer un taux horaire utilisé par des prestations non facturées » échoue avec un 200 au lieu d'un 403, et la prestation a disparu (`null`) — c'est exactement la perte de données qu'on corrige.
+
+- [ ] **Step 3: Refuser la suppression d'un taux encore utilisé**
+
+Dans `app/Policies/TauxHorairePolicy.php`, remplacer la méthode `delete` (la méthode `update` reste telle que la tâche 1 l'a laissée) et ajouter l'import :
+
+```php
+use Illuminate\Auth\Access\Response;
+```
+
+```php
+    /**
+     * L'utilisateur peut supprimer un taux horaire **s'il en est le propriétaire**
+     * et **si aucune prestation ne l'utilise** — facturée ou non.
+     *
+     * Sans ce garde-fou, la cascade de la base détruirait silencieusement les
+     * prestations non facturées qui s'appuient sur ce taux.
+     */
+    public function delete(User $user, TauxHoraire $tauxHoraire): Response|bool
+    {
+        // La propriété d'abord : le message de refus ci-dessous ne doit jamais
+        // renseigner un intrus sur le volume d'activité d'autrui.
+        if ($user->id !== $tauxHoraire->user_id) {
+            return false;
+        }
+
+        $nombre = $tauxHoraire->prestations()->count();
+
+        if ($nombre > 0) {
+            return Response::deny(
+                "Ce taux horaire est utilisé par {$nombre} prestation" . ($nombre > 1 ? 's' : '') . '. '
+                . 'Modifiez leur taux ou supprimez-les avant de le supprimer.'
+            );
+        }
+
+        return true;
+    }
+```
+
+- [ ] **Step 4: Refuser la suppression d'un client encore utilisé**
+
+Dans `app/Policies/ClientPolicy.php`, ajouter l'import et remplacer la méthode `delete` (`update` reste inchangé : modifier un client est sans danger) :
+
+```php
+use Illuminate\Auth\Access\Response;
+```
+
+```php
+    /**
+     * L'utilisateur peut supprimer un client **s'il en est le propriétaire**
+     * et **si aucune prestation ne lui est rattachée**.
+     *
+     * Sans ce garde-fou, la cascade de la base détruirait ses prestations —
+     * y compris facturées, laissant des factures sans lignes dont le PDF échoue.
+     */
+    public function delete(User $user, Client $client): Response|bool
+    {
+        if ($user->id !== $client->user_id) {
+            return false;
+        }
+
+        $nombre = $client->prestations()->count();
+
+        if ($nombre > 0) {
+            return Response::deny(
+                "Ce client a {$nombre} prestation" . ($nombre > 1 ? 's' : '') . '. '
+                . 'Supprimez-les avant de supprimer le client.'
+            );
+        }
+
+        return true;
+    }
+```
+
+- [ ] **Step 5: Lancer les tests et vérifier qu'ils passent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/SuppressionNonDestructiveTest.php`
+Expected: PASS — 7 tests.
+
+- [ ] **Step 6: Lancer la suite complète**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 78 tests (71 + 7). Si un test préexistant échoue, c'est qu'il supprimait un client ou un taux encore utilisé : lis-le, et détermine s'il testait le comportement destructeur (auquel cas il doit être corrigé) ou autre chose (auquel cas ta policy est trop stricte). Ne le supprime pas sans comprendre.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/Policies/TauxHorairePolicy.php app/Policies/ClientPolicy.php tests/Feature/SuppressionNonDestructiveTest.php
+git commit -m "fix: refuse la suppression d'un taux ou client encore utilise"
+```
+
+---
+
+### Task 3 : La base refuse aussi (défense en profondeur)
+
+Les policies protègent les routes. La base doit protéger le reste : commandes artisan, seeders, futurs endpoints. Aujourd'hui elle obéit et détruit.
+
+**Files:**
+- Create: `database/migrations/<timestamp>_restreint_suppression_prestations.php`
+- Test: `tests/Feature/ContrainteIntegritePrestationsTest.php`
+
+**Interfaces:**
+- Consumes: rien (indépendant des policies).
+- Produces: `prestations.client_id` et `prestations.taux_horaire_id` sont en `RESTRICT`. `prestations.user_id` reste en `CASCADE`.
+
+Vérifié au préalable : Laravel 12.1.1 sait exécuter `dropForeign` sur SQLite (il recrée la table), donc cette migration passe aussi bien en test qu'en production MySQL.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/Feature/ContrainteIntegritePrestationsTest.php` :
+
+```php
+<?php
+
+use App\Models\Client;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('la base refuse de supprimer un taux horaire encore utilise, meme hors policy', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+    ]);
+
+    // Suppression directe, en contournant complètement les policies.
+    expect(fn () => $taux->delete())->toThrow(QueryException::class);
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+});
+
+it('la base refuse de supprimer un client encore utilise, meme hors policy', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+    ]);
+
+    expect(fn () => $client->delete())->toThrow(QueryException::class);
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+});
+
+it('la suppression d\'un utilisateur emporte toujours ses donnees', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+    ]);
+
+    // user_id reste en CASCADE : supprimer un compte doit tout emporter.
+    // Ce test existe parce que RESTRICT sur client_id / taux_horaire_id
+    // pourrait faire échouer cette cascade selon l'ordre choisi par la base.
+    $user->delete();
+
+    expect(Prestation::find($prestation->id))->toBeNull();
+    expect(Client::find($client->id))->toBeNull();
+    expect(TauxHoraire::find($taux->id))->toBeNull();
+});
+```
+
+> Ce troisième test est le point de vigilance de la spec. **S'il échoue**, c'est que la cascade sur `user_id` entre en conflit avec les nouvelles contraintes `RESTRICT` : la base tente de supprimer les clients et les taux avant les prestations. NE le supprime PAS et ne le contourne pas. La correction est d'ajouter un observateur qui supprime les prestations en premier — décris précisément l'échec dans ton rapport et signale-le, c'est une décision de conception qui ne t'appartient pas.
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/ContrainteIntegritePrestationsTest.php`
+Expected: les deux premiers tests ÉCHOUENT — aucune exception n'est levée, la suppression réussit et détruit la prestation (`CASCADE` actuel). Le troisième passe déjà.
+
+- [ ] **Step 3: Créer la migration**
+
+Run: `php artisan make:migration restreint_suppression_prestations --table=prestations`
+
+Remplacer le corps du fichier généré par :
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Empêche la base de détruire des prestations en cascade.
+     *
+     * `client_id` et `taux_horaire_id` étaient en CASCADE : supprimer un client
+     * ou un taux horaire détruisait silencieusement ses prestations — y compris
+     * facturées. Les policies refusent désormais ces suppressions ; la base doit
+     * refuser aussi, pour tout ce qui ne passe pas par elles (commandes artisan,
+     * seeders, futurs endpoints).
+     *
+     * `user_id` reste en CASCADE : supprimer un compte doit bien tout emporter.
+     */
+    public function up(): void
+    {
+        Schema::table('prestations', function (Blueprint $table) {
+            $table->dropForeign(['client_id']);
+            $table->foreign('client_id')->references('id')->on('clients')->restrictOnDelete();
+
+            $table->dropForeign(['taux_horaire_id']);
+            $table->foreign('taux_horaire_id')->references('id')->on('taux_horaires')->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('prestations', function (Blueprint $table) {
+            $table->dropForeign(['client_id']);
+            $table->foreign('client_id')->references('id')->on('clients')->cascadeOnDelete();
+
+            $table->dropForeign(['taux_horaire_id']);
+            $table->foreign('taux_horaire_id')->references('id')->on('taux_horaires')->cascadeOnDelete();
+        });
+    }
+};
+```
+
+- [ ] **Step 4: Lancer les tests et vérifier qu'ils passent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/ContrainteIntegritePrestationsTest.php`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Lancer la suite complète**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 81 tests (78 + 3).
+
+- [ ] **Step 6: Vérifier la migration sur MySQL, pas seulement sur SQLite**
+
+Les tests tournent sur SQLite, la production sur MySQL — une migration peut passer sur l'un et échouer sur l'autre. Le container de développement expose une vraie base MySQL.
+
+Run: `docker compose exec -T app php artisan migrate --force`
+Expected: la migration `restreint_suppression_prestations` s'applique, `DONE`.
+
+Si Docker n'est pas disponible dans l'environnement, ne prétends pas avoir vérifié : dis-le dans ton rapport.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add database/migrations tests/Feature/ContrainteIntegritePrestationsTest.php
+git commit -m "fix: la base refuse de detruire des prestations en cascade"
+```
+
+---
+
+## Vérification finale
+
+- [ ] `php artisan test --testsuite=Feature` — 81 tests verts.
+- [ ] Contrôle manuel dans l'application (http://localhost:8080) : tenter de supprimer un taux horaire utilisé par des prestations → un toast rouge explique le refus (« Ce taux horaire est utilisé par N prestations… »), et les prestations sont toujours là. Aucun changement front n'était nécessaire : le store relaie déjà le message de l'API.
+- [ ] Même contrôle sur la suppression d'un client ayant des prestations.
+- [ ] Supprimer un taux horaire qui n'a aucune prestation → fonctionne toujours.

--- a/docs/superpowers/specs/2026-07-12-securite-taux-horaires-et-suppressions-design.md
+++ b/docs/superpowers/specs/2026-07-12-securite-taux-horaires-et-suppressions-design.md
@@ -1,0 +1,162 @@
+# Sécurité des taux horaires et suppressions non destructrices
+
+Date : 2026-07-12
+
+## Problème
+
+Deux défauts, tous deux en production, vérifiés en exerçant l'API réelle (pas
+par lecture de code).
+
+### 1. Faille IDOR sur les taux horaires (critique)
+
+`TauxHorairePolicy::update` et `::delete` ne vérifient **pas la propriété** : elles
+ne regardent que l'existence de prestations facturées.
+
+```php
+public function update(User $user, TauxHoraire $tauxHoraire): bool
+{
+    return !$tauxHoraire->prestations()->whereNotNull('facture_id')->exists();
+}
+```
+
+`$user` n'est jamais comparé à `$tauxHoraire->user_id`. Constaté :
+
+- `PUT /api/taux-horaires/{id}` par un utilisateur tiers → **200**, le taux passe
+  de 60 € à 1 €.
+- `DELETE /api/taux-horaires/{id}` par un utilisateur tiers → **200**, le taux est
+  détruit — **et ses prestations avec lui**, via la cascade décrite ci-dessous.
+
+Un utilisateur peut donc détruire le travail d'un autre. La liste des taux est
+correctement cloisonnée (un tiers ne voit pas ceux des autres), mais les
+identifiants sont séquentiels : ce n'est pas une protection.
+
+L'audit de sécurité du 2026-07-10 a corrigé les IDOR sur les factures et les
+prestations. Les taux horaires ont été oubliés.
+
+### 2. Suppressions destructrices en cascade (perte de données)
+
+`prestations` déclare :
+
+```php
+$table->foreignId('client_id')->constrained('clients')->onDelete('cascade');
+$table->foreignId('taux_horaire_id')->constrained('taux_horaires')->onDelete('cascade');
+```
+
+Conséquences constatées :
+
+- Supprimer un taux horaire **jamais facturé** → 200, et **toutes ses prestations
+  non facturées sont supprimées**, silencieusement. Scénario réel : importer le
+  relevé du mois (25 prestations, 238 h), faire du ménage dans les taux, en
+  supprimer un vieux → le mois de travail disparaît.
+- Supprimer un client → `ClientPolicy::delete` ne vérifie que la propriété, donc
+  la suppression passe et détruit **toutes** ses prestations, y compris
+  **facturées**. Les factures restent alors sans lignes, et leur PDF échoue
+  (`getPdf()` fait `$facture->prestations->first()->client` sur une collection
+  vide).
+
+## Décisions
+
+**Refuser la suppression plutôt que détruire.** Deux alternatives ont été
+écartées :
+
+- *Demander confirmation dans l'UI* — la suppression en masse resterait possible
+  d'un clic, et l'API resterait destructrice pour tout autre appelant.
+- *Archiver (soft delete)* — élégant à long terme, mais c'est un changement de
+  modèle bien plus large (migration, filtrage de toutes les listes de sélection,
+  désarchivage) pour un besoin qui ne s'est pas manifesté.
+
+**Corriger l'IDOR et la cascade ensemble.** C'est le même fichier de policies, et
+fermer la propriété sans corriger la cascade laisserait l'utilisateur détruire
+ses *propres* données par accident.
+
+**Une migration en défense en profondeur.** Les policies protègent les routes ;
+la base doit protéger le reste (commandes artisan, seeders, futurs endpoints).
+Aujourd'hui elle obéit et détruit.
+
+## Conception
+
+### Les policies
+
+| Fichier | Changement |
+|---|---|
+| `app/Policies/TauxHorairePolicy.php` | `update` et `delete` vérifient la propriété (`$user->id === $tauxHoraire->user_id`). `delete` refuse en outre si le taux a **des prestations, facturées ou non**. |
+| `app/Policies/ClientPolicy.php` | `delete` refuse si le client a **des prestations**. `update` reste inchangé (modifier un client est sans danger). |
+| `app/Policies/PrestationPolicy.php` | Inchangé — il refuse déjà la modification et la suppression d'une prestation facturée. |
+
+`TauxHorairePolicy::update` continue d'autoriser la modification d'un taux dont
+les prestations ne sont **pas** facturées : c'est légitime, ces prestations ne
+sont pas encore figées dans une facture.
+
+Les refus liés à un usage existant renvoient un message explicite via
+`Illuminate\Auth\Access\Response::deny()`, et non un `false` muet. L'utilisateur
+doit comprendre pourquoi il ne peut pas supprimer :
+
+- Taux : « Ce taux horaire est utilisé par N prestation(s). Modifiez leur taux ou
+  supprimez-les avant de le supprimer. »
+- Client : « Ce client a N prestation(s). Supprimez-les avant de le supprimer. »
+
+Le refus lié à la **propriété**, lui, reste un `false` muet : expliquer à un
+intrus pourquoi il est refusé lui apprendrait que la ressource existe.
+
+**L'ordre des vérifications compte, et il est imposé : la propriété d'abord, l'usage
+ensuite.** Si la policy comptait les prestations avant de vérifier le propriétaire,
+son message de refus (« ce taux est utilisé par 25 prestations ») révélerait à un
+intrus le volume d'activité d'un autre utilisateur — une fuite d'information par le
+message d'erreur, alors même que l'accès est refusé.
+
+### La migration
+
+Une migration passe les deux clés étrangères de `prestations` de
+`onDelete('cascade')` à `restrictOnDelete()` :
+
+- `client_id`
+- `taux_horaire_id`
+
+`user_id` **reste en cascade** : supprimer un compte doit bien tout emporter.
+
+**Point de vigilance à vérifier, pas à supposer** : avec `restrict` sur
+`client_id` et `taux_horaire_id`, la suppression d'un `User` (dont la cascade
+`user_id` supprime prestations, clients et taux) pourrait échouer selon l'ordre
+dans lequel la base traite les cascades. Il n'existe aujourd'hui aucune route de
+suppression de compte, donc le risque est théorique — mais un test doit le
+confirmer plutôt que le postuler. Si la suppression d'un `User` échoue, la
+migration devra ordonner la suppression (supprimer les prestations avant les
+clients et les taux, dans un observateur de modèle ou une transaction).
+
+### L'UI
+
+`TauxHoraireDeleteModal.vue` et `ClientDeleteModal.vue` doivent afficher le
+message renvoyé par l'API en cas de refus, au lieu d'une erreur brute. Le message
+existe déjà côté serveur (`Response::deny`), il suffit de le relayer — c'est le
+pattern déjà en place pour les autres erreurs du store.
+
+## Tests
+
+Du vrai TDD : c'est du backend, et la suite Pest existe (68 tests verts).
+
+**Sécurité (le test échoue aujourd'hui — c'est la preuve que la faille est réelle) :**
+- Un tiers ne peut pas modifier le taux horaire d'autrui → 403, taux inchangé.
+- Un tiers ne peut pas supprimer le taux horaire d'autrui → 403, taux toujours là.
+
+**Suppressions :**
+- Supprimer un taux avec des prestations **non facturées** → 403, et **aucune
+  prestation supprimée** (l'assertion sur la survie des prestations est le cœur
+  du test : c'est la perte de données qu'on prévient).
+- Supprimer un taux avec des prestations **facturées** → 403 (déjà le cas,
+  verrouillé par un test).
+- Supprimer un taux **sans aucune prestation** → 200, il disparaît.
+- Supprimer un client avec des prestations → 403, aucune prestation supprimée.
+- Supprimer un client sans prestation → 200.
+
+**Défense en profondeur :**
+- Une suppression directe en base (hors policy) d'un taux encore utilisé doit
+  lever une erreur d'intégrité — preuve que `restrictOnDelete` est bien en place.
+- La suppression d'un `User` fonctionne toujours (le point de vigilance ci-dessus).
+
+## Hors périmètre
+
+- Le soft delete / archivage des taux et clients.
+- La réaffectation en masse des prestations d'un taux vers un autre (ce serait la
+  suite naturelle si le refus devenait pénible à l'usage).
+- Les autres policies (`FacturePolicy`, `PrestationPolicy`), qui vérifient déjà
+  correctement la propriété.

--- a/tests/Feature/ContrainteIntegritePrestationsTest.php
+++ b/tests/Feature/ContrainteIntegritePrestationsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\DeleteUser;
 use App\Models\Client;
 use App\Models\Facture;
 use App\Models\Prestation;
@@ -68,7 +69,10 @@ it('la suppression d\'un utilisateur emporte toujours ses donnees', function () 
     // Depuis le correctif, UserObserver::deleting() supprime explicitement
     // les prestations de l'utilisateur avant que la cascade native ne
     // s'attaque à ses clients, taux horaires et factures.
-    $user->delete();
+    //
+    // Passe par App\Actions\DeleteUser, seul point d'entrée valide pour
+    // supprimer un compte (voir son docblock).
+    (new DeleteUser())->execute($user);
 
     expect(Prestation::find($prestation->id))->toBeNull();
     expect(Client::find($client->id))->toBeNull();

--- a/tests/Feature/ContrainteIntegritePrestationsTest.php
+++ b/tests/Feature/ContrainteIntegritePrestationsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Client;
+use App\Models\Facture;
 use App\Models\Prestation;
 use App\Models\TauxHoraire;
 use App\Models\User;
@@ -43,22 +44,34 @@ it('la base refuse de supprimer un client encore utilise, meme hors policy', fun
 });
 
 it('la suppression d\'un utilisateur emporte toujours ses donnees', function () {
-    $user   = User::factory()->create();
-    $client = Client::factory()->create(['user_id' => $user->id]);
-    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+    // ATTENTION : ce test tourne sur SQLite (RefreshDatabase / phpunit.xml),
+    // dont l'ordre de résolution des cascades diffère de MySQL/InnoDB. Il
+    // passait déjà AVANT le correctif (UserObserver) et ne prouve donc pas,
+    // à lui seul, que la suppression fonctionne réellement en production.
+    // La preuve du correctif est une vérification manuelle sur MySQL réel
+    // (container Docker) — voir le rapport de correctif.
+    $user    = User::factory()->create();
+    $client  = Client::factory()->create(['user_id' => $user->id]);
+    $taux    = TauxHoraire::factory()->create(['user_id' => $user->id]);
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
 
     $prestation = Prestation::factory()->create([
         'user_id'         => $user->id,
         'client_id'       => $client->id,
         'taux_horaire_id' => $taux->id,
+        'facture_id'      => $facture->id,
     ]);
 
     // user_id reste en CASCADE : supprimer un compte doit tout emporter.
     // Ce test existe parce que RESTRICT sur client_id / taux_horaire_id
     // pourrait faire échouer cette cascade selon l'ordre choisi par la base.
+    // Depuis le correctif, UserObserver::deleting() supprime explicitement
+    // les prestations de l'utilisateur avant que la cascade native ne
+    // s'attaque à ses clients, taux horaires et factures.
     $user->delete();
 
     expect(Prestation::find($prestation->id))->toBeNull();
     expect(Client::find($client->id))->toBeNull();
     expect(TauxHoraire::find($taux->id))->toBeNull();
+    expect(Facture::find($facture->id))->toBeNull();
 });

--- a/tests/Feature/ContrainteIntegritePrestationsTest.php
+++ b/tests/Feature/ContrainteIntegritePrestationsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('la base refuse de supprimer un taux horaire encore utilise, meme hors policy', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+    ]);
+
+    // Suppression directe, en contournant complètement les policies.
+    expect(fn () => $taux->delete())->toThrow(QueryException::class);
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+});
+
+it('la base refuse de supprimer un client encore utilise, meme hors policy', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+    ]);
+
+    expect(fn () => $client->delete())->toThrow(QueryException::class);
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+});
+
+it('la suppression d\'un utilisateur emporte toujours ses donnees', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+    ]);
+
+    // user_id reste en CASCADE : supprimer un compte doit tout emporter.
+    // Ce test existe parce que RESTRICT sur client_id / taux_horaire_id
+    // pourrait faire échouer cette cascade selon l'ordre choisi par la base.
+    $user->delete();
+
+    expect(Prestation::find($prestation->id))->toBeNull();
+    expect(Client::find($client->id))->toBeNull();
+    expect(TauxHoraire::find($taux->id))->toBeNull();
+});

--- a/tests/Feature/DeleteUserActionTest.php
+++ b/tests/Feature/DeleteUserActionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Actions\DeleteUser;
+use App\Models\Client;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('n\'efface aucune prestation si la suppression du user echoue apres coup (atomicite)', function () {
+    // ATTENTION : ce test tourne sur SQLite et ne reproduit PAS l'erreur
+    // MySQL/InnoDB 1451 (cascade concurrente + RESTRICT) qui a motivé le
+    // correctif — il ne prouve donc pas, à lui seul, que la suppression
+    // fonctionne sur MySQL (voir le rapport de correctif pour la preuve
+    // MySQL réelle). Il prouve en revanche que la transaction ouverte par
+    // DeleteUser::execute() est réelle : si un autre listener échoue APRÈS
+    // le passage de UserObserver, tout est annulé — y compris les
+    // prestations que l'observer avait déjà supprimées.
+    //
+    // Avant le correctif, UserObserver ouvrait lui-même une transaction qui
+    // committait seule, indépendamment du sort de la suppression du user :
+    // dans ce même scénario, les prestations auraient été détruites pour
+    // rien, alors que le user, lui, existerait toujours.
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    // Un listener enregistré après UserObserver (donc déclenché après lui)
+    // simule un échec en aval : veto d'un autre observer, exception,
+    // deadlock... Reproduit le scénario décrit dans la revue.
+    User::deleting(function () {
+        throw new RuntimeException('Echec simulé après le passage de UserObserver.');
+    });
+
+    expect(fn () => (new DeleteUser())->execute($user))
+        ->toThrow(RuntimeException::class);
+
+    expect(User::find($user->id))->not->toBeNull();
+    expect(Client::find($client->id))->not->toBeNull();
+    expect(TauxHoraire::find($taux->id))->not->toBeNull();
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+});
+
+it('supprime bien l\'utilisateur et ses prestations quand rien n\'echoue', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    (new DeleteUser())->execute($user);
+
+    expect(User::find($user->id))->toBeNull();
+    expect(Prestation::find($prestation->id))->toBeNull();
+});

--- a/tests/Feature/SuppressionNonDestructiveTest.php
+++ b/tests/Feature/SuppressionNonDestructiveTest.php
@@ -128,6 +128,7 @@ it('ne revele rien a un intrus dans le message de refus', function () {
 
     $response->assertForbidden();
 
-    // Le refus ne doit PAS trahir le volume d'activité du propriétaire.
-    expect($response->json('message'))->not->toContain('25');
+    // Le refus ne doit PAS trahir le volume d'activité du propriétaire,
+    // quel que soit le nombre de prestations du fixture.
+    expect($response->json('message'))->not->toMatch('/\d/');
 });

--- a/tests/Feature/SuppressionNonDestructiveTest.php
+++ b/tests/Feature/SuppressionNonDestructiveTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Facture;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('refuse de supprimer un taux horaire utilise par des prestations non facturees, sans rien detruire', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,   // NON facturée
+    ]);
+
+    $response = $this->actingAs($user)->deleteJson("/api/taux-horaires/{$taux->id}");
+
+    $response->assertForbidden();
+
+    // Le cœur du test : la prestation ne doit PAS avoir été détruite en cascade.
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+    expect(TauxHoraire::find($taux->id))->not->toBeNull();
+});
+
+it('refuse de supprimer un taux horaire deja facture', function () {
+    $user    = User::factory()->create();
+    $client  = Client::factory()->create(['user_id' => $user->id]);
+    $taux    = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+    $facture = Facture::factory()->create(['user_id' => $user->id]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => $facture->id,
+    ]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/taux-horaires/{$taux->id}")
+        ->assertForbidden();
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+});
+
+it('autorise la suppression d\'un taux horaire sans aucune prestation', function () {
+    $user = User::factory()->create();
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/taux-horaires/{$taux->id}")
+        ->assertOk();
+
+    expect(TauxHoraire::find($taux->id))->toBeNull();
+});
+
+it('refuse de supprimer un client qui a des prestations, sans rien detruire', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $prestation = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/clients/{$client->id}")
+        ->assertForbidden();
+
+    expect(Prestation::find($prestation->id))->not->toBeNull();
+    expect(Client::find($client->id))->not->toBeNull();
+});
+
+it('autorise la suppression d\'un client sans prestation', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->deleteJson("/api/clients/{$client->id}")
+        ->assertOk();
+
+    expect(Client::find($client->id))->toBeNull();
+});
+
+it('explique pourquoi la suppression est refusee', function () {
+    $user   = User::factory()->create();
+    $client = Client::factory()->create(['user_id' => $user->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    Prestation::factory()->count(3)->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    $response = $this->actingAs($user)->deleteJson("/api/taux-horaires/{$taux->id}");
+
+    // Le message doit être exploitable : il dit combien de prestations bloquent.
+    expect($response->json('message'))->toContain('3 prestations');
+});
+
+it('ne revele rien a un intrus dans le message de refus', function () {
+    $proprietaire = User::factory()->create();
+    $intrus       = User::factory()->create();
+
+    $client = Client::factory()->create(['user_id' => $proprietaire->id]);
+    $taux   = TauxHoraire::factory()->create(['user_id' => $proprietaire->id, 'taux' => 60]);
+
+    Prestation::factory()->count(25)->create([
+        'user_id'         => $proprietaire->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+    ]);
+
+    $response = $this->actingAs($intrus)->deleteJson("/api/taux-horaires/{$taux->id}");
+
+    $response->assertForbidden();
+
+    // Le refus ne doit PAS trahir le volume d'activité du propriétaire.
+    expect($response->json('message'))->not->toContain('25');
+});

--- a/tests/Feature/TauxHoraireSecurityTest.php
+++ b/tests/Feature/TauxHoraireSecurityTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('interdit a un tiers de modifier le taux horaire d\'un autre utilisateur', function () {
+    $proprietaire = User::factory()->create();
+    $intrus       = User::factory()->create();
+
+    $taux = TauxHoraire::factory()->create([
+        'user_id' => $proprietaire->id,
+        'taux'    => 60,
+    ]);
+
+    $this->actingAs($intrus)
+        ->putJson("/api/taux-horaires/{$taux->id}", ['taux' => 1])
+        ->assertForbidden();
+
+    // Le taux ne doit pas avoir bougé.
+    expect((float) $taux->fresh()->taux)->toBe(60.0);
+});
+
+it('interdit a un tiers de supprimer le taux horaire d\'un autre utilisateur', function () {
+    $proprietaire = User::factory()->create();
+    $intrus       = User::factory()->create();
+
+    $taux = TauxHoraire::factory()->create(['user_id' => $proprietaire->id, 'taux' => 60]);
+
+    $this->actingAs($intrus)
+        ->deleteJson("/api/taux-horaires/{$taux->id}")
+        ->assertForbidden();
+
+    expect(TauxHoraire::find($taux->id))->not->toBeNull();
+});
+
+it('autorise le proprietaire a modifier son propre taux horaire non facture', function () {
+    $user = User::factory()->create();
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 60]);
+
+    $this->actingAs($user)
+        ->putJson("/api/taux-horaires/{$taux->id}", ['taux' => 65])
+        ->assertOk();
+
+    expect((float) $taux->fresh()->taux)->toBe(65.0);
+});


### PR DESCRIPTION
Deux défauts en production, tous deux constatés en exerçant l'API réelle — pas déduits d'une lecture de code.

## 1. Une faille IDOR (critique)

`TauxHorairePolicy::update` et `::delete` ne vérifiaient **jamais la propriété** : elles ne regardaient que l'existence de prestations facturées. Constaté :

- `PUT /api/taux-horaires/{id}` par un tiers → **200**, le taux passe de 60 € à 1 €.
- `DELETE /api/taux-horaires/{id}` par un tiers → **200**, détruit — **et ses prestations avec**, via la cascade ci-dessous.

Un utilisateur pouvait donc détruire le travail d'un autre. L'audit de sécurité du 10/07 (PR #16) avait corrigé les IDOR sur les factures et les prestations ; les taux horaires avaient été oubliés.

Les policies vérifient désormais la propriété, **en premier** — avant tout comptage, pour qu'aucun message de refus ne révèle à un intrus le volume d'activité d'autrui.

## 2. Une perte de données silencieuse

`prestations` déclarait `onDelete('cascade')` sur `client_id` et `taux_horaire_id`.

- Supprimer un taux **jamais facturé** → 200, et **toutes ses prestations non facturées détruites**, sans confirmation. Scénario réel : importer son relevé du mois (25 prestations, 238 h), faire du ménage dans ses taux, en supprimer un vieux → le mois de travail disparaît.
- Supprimer un client → détruisait **toutes** ses prestations, y compris **facturées**, laissant des factures sans lignes dont le PDF échoue.

Les policies refusent désormais ces suppressions, avec un message qui indique le chemin réellement praticable. Et une migration passe les deux clés en `restrictOnDelete()` : la base refuse aussi, pour tout ce qui ne passe pas par les policies (commandes artisan, seeders, futurs endpoints).

## Ce que la revue a rattrapé

**La migration cassait la suppression d'un compte utilisateur — sur MySQL seulement.** La cascade de `user_id` heurtait le nouveau `RESTRICT` (`SQLSTATE 23000`). Le test passait sur SQLite, qui résout l'ordre des cascades différemment : **notre suite de tests est structurellement aveugle à ce genre de bug**, puisqu'elle tourne sur SQLite et la production sur MySQL. Corrigé par un `UserObserver` qui supprime les prestations en premier.

**Le premier correctif de cet observateur introduisait lui-même le bug qu'il prétendait fermer.** `Model::delete()` n'ouvre pas de transaction — il déclenche `deleting` *puis* supprime. La transaction de l'observateur committait donc seule : si la suppression échouait ensuite, les prestations étaient détruites et l'utilisateur restait. Corrigé par une action `DeleteUser` qui enveloppe l'ensemble. Vérifié sur MySQL avec un test négatif **et** un contrôle (sans la transaction, la prestation est bien perdue — le scénario est donc probant).

**Les messages de refus envoyaient l'utilisateur dans un mur** : ils disaient « supprimez les prestations », alors que `PrestationPolicy` interdit de supprimer une prestation facturée. Ils distinguent désormais les prestations facturées des autres, et donnent le chemin complet (supprimer la facture, *puis* les prestations détachées — car supprimer une facture ne fait que les détacher).

## Vérifications

- `php artisan test --testsuite=Feature` : **83 tests, 250 assertions**, verts.
- Migration appliquée sur la **vraie base MySQL** du container, contraintes relues dans `information_schema` : `client_id`→RESTRICT, `taux_horaire_id`→RESTRICT, `user_id`→CASCADE.
- Suppression d'un compte vérifiée sur MySQL (cas nominal et cas d'échec à mi-parcours).
- Aucune fuite d'information : un intrus reçoit un 403 nu, sans aucun chiffre.

## Dettes ouvertes

- **Les tests tournent sur SQLite, la production sur MySQL.** C'est ce qui a masqué le bug de cascade. Faire tourner la suite sur MySQL en CI est la vraie réponse — chantier à part.
- **Re-facturer une prestation déjà facturée vide silencieusement la facture précédente** (`FactureRequest` n'exige pas `facture_id = null`). La facture devient une coquille qui affiche toujours son montant, et son PDF plante. Préexistant, atteignable en une requête API — mérite un ticket.

Spec et plan : `docs/superpowers/specs/2026-07-12-securite-taux-horaires-et-suppressions-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj