### PR TITLE
CI : faire tourner la suite de tests sur MySQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,32 @@ jobs:
     name: Tests (Pest)
     runs-on: ubuntu-latest
 
+    # La suite tourne sur MySQL, le moteur de la production.
+    # SQLite (utilisé en local pour la vitesse) résout les cascades et les
+    # contraintes d'intégrité différemment : il a déjà laissé passer deux bugs
+    # de perte de données (cf. PR #22).
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: promeb_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: promeb_test
+      DB_USERNAME: root
+      DB_PASSWORD: root
+
     steps:
       - name: Checkout du code
         uses: actions/checkout@v4
@@ -19,7 +45,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: pdo, pdo_sqlite, mbstring, zip, exif, pcntl, gd, bcmath, intl
+          extensions: pdo, pdo_mysql, pdo_sqlite, mbstring, zip, exif, pcntl, gd, bcmath, intl
           coverage: none
 
       - name: Cache des dépendances Composer
@@ -36,6 +62,11 @@ jobs:
         run: |
           cp .env.example .env
           php artisan key:generate
+
+      # Preuve que la suite tourne bien sur MySQL. Une CI verte ne suffit pas :
+      # si la connexion retombait sur SQLite, elle serait verte ET aveugle.
+      - name: Vérification de la connexion à la base
+        run: php artisan db:show
 
       - name: Exécution des tests
         run: php artisan test --testsuite=Feature

--- a/bin/test-mysql.sh
+++ b/bin/test-mysql.sh
@@ -11,20 +11,43 @@
 
 set -euo pipefail
 
+# `docker compose` doit être lancé depuis la racine du dépôt (c'est là que vit
+# docker-compose.yml). Se placer explicitement ici pour que le script
+# fonctionne quel que soit le répertoire courant de l'appelant.
+cd "$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+
 BASE_DE_TEST="promeb_test"
 BASE_DE_DEV="my_event_app"
 
-# Garde-fou : la suite utilise RefreshDatabase, qui DÉTRUIT et recrée les tables.
-# La pointer sur la base de développement effacerait les données de travail.
 if [ "$BASE_DE_TEST" = "$BASE_DE_DEV" ]; then
     echo "ERREUR : la base de test ne peut pas être la base de développement (${BASE_DE_DEV})." >&2
     echo "RefreshDatabase détruirait vos données. Abandon." >&2
     exit 1
 fi
 
+# Garde-fou réel : la suite utilise RefreshDatabase, qui DÉTRUIT et recrée les
+# tables. On ne peut pas se fier à la comparaison de deux constantes bash, ni
+# au fait d'avoir *demandé* DB_DATABASE=promeb_test via `-e` — un
+# bootstrap/cache/config.php périmé fait passer cette variable au second plan
+# et Laravel résout alors la base figée dans le cache (potentiellement
+# my_event_app, la base de développement). La seule vérification qui vaille
+# est de demander à Laravel, depuis l'intérieur du container, quelle base il
+# résout *effectivement*.
+echo "→ Vérification de la base effectivement résolue par Laravel…"
+BASE_EFFECTIVE=$(docker compose exec -T -e HOME=/tmp -e DB_CONNECTION=mysql -e DB_DATABASE="$BASE_DE_TEST" app \
+    php artisan tinker --execute='echo config("database.connections.mysql.database");' | tr -d '\r\n')
+
+if [ "$BASE_EFFECTIVE" != "$BASE_DE_TEST" ]; then
+    echo "ERREUR : Laravel résout la base « ${BASE_EFFECTIVE} » au lieu de « ${BASE_DE_TEST} »." >&2
+    echo "Un config cache (bootstrap/cache/config.php) masque probablement les variables d'environnement." >&2
+    echo "Lancez : docker compose exec app php artisan config:clear" >&2
+    exit 1
+fi
+
 echo "→ Préparation de la base de test « ${BASE_DE_TEST} »…"
 docker compose exec -T db mysql -uroot -prootpassword \
-    -e "CREATE DATABASE IF NOT EXISTS ${BASE_DE_TEST}; GRANT ALL PRIVILEGES ON ${BASE_DE_TEST}.* TO 'laravel'@'%'; FLUSH PRIVILEGES;" 2>/dev/null
+    -e "CREATE DATABASE IF NOT EXISTS ${BASE_DE_TEST}; GRANT ALL PRIVILEGES ON ${BASE_DE_TEST}.* TO 'laravel'@'%'; FLUSH PRIVILEGES;" \
+    2> >(grep -v '^mysql: \[Warning\] Using a password on the command line interface can be insecure\.$' >&2)
 
 echo "→ Exécution de la suite sur MySQL…"
 docker compose exec -T \

--- a/bin/test-mysql.sh
+++ b/bin/test-mysql.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Lance la suite de tests sur MySQL — le moteur de la production.
+#
+# Par défaut, `php artisan test` tourne sur SQLite en mémoire (rapide, mais il
+# résout les cascades et les contraintes d'intégrité autrement que MySQL : il a
+# déjà laissé passer deux bugs de perte de données). Utilisez ce script dès que
+# vous touchez aux cascades, aux contraintes d'intégrité ou aux suppressions.
+#
+# Nécessite que le container de développement tourne (`docker compose up -d`).
+
+set -euo pipefail
+
+BASE_DE_TEST="promeb_test"
+BASE_DE_DEV="my_event_app"
+
+# Garde-fou : la suite utilise RefreshDatabase, qui DÉTRUIT et recrée les tables.
+# La pointer sur la base de développement effacerait les données de travail.
+if [ "$BASE_DE_TEST" = "$BASE_DE_DEV" ]; then
+    echo "ERREUR : la base de test ne peut pas être la base de développement (${BASE_DE_DEV})." >&2
+    echo "RefreshDatabase détruirait vos données. Abandon." >&2
+    exit 1
+fi
+
+echo "→ Préparation de la base de test « ${BASE_DE_TEST} »…"
+docker compose exec -T db mysql -uroot -prootpassword \
+    -e "CREATE DATABASE IF NOT EXISTS ${BASE_DE_TEST}; GRANT ALL PRIVILEGES ON ${BASE_DE_TEST}.* TO 'laravel'@'%'; FLUSH PRIVILEGES;" 2>/dev/null
+
+echo "→ Exécution de la suite sur MySQL…"
+docker compose exec -T \
+    -e HOME=/tmp \
+    -e DB_CONNECTION=mysql \
+    -e DB_HOST=db \
+    -e DB_PORT=3306 \
+    -e DB_DATABASE="${BASE_DE_TEST}" \
+    -e DB_USERNAME=laravel \
+    -e DB_PASSWORD=secret \
+    app php artisan test --testsuite=Feature "$@"

--- a/docs/superpowers/plans/2026-07-12-tests-sur-mysql-en-ci.md
+++ b/docs/superpowers/plans/2026-07-12-tests-sur-mysql-en-ci.md
@@ -1,0 +1,275 @@
+# Tests sur MySQL en CI — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Faire tourner la suite de tests sur MySQL en CI — le moteur de la production — au lieu de SQLite, qui a déjà laissé passer deux bugs de cascade.
+
+**Architecture :** Le workflow GitHub Actions gagne un service `mysql:8.0` et pointe les tests dessus via des variables d'environnement. `phpunit.xml` n'est pas touché : les variables du système priment sur ses `<env>`, donc le développement local continue de tourner sur SQLite, instantanément. Un script encapsule la commande pour lancer la suite sur MySQL en local quand c'est nécessaire.
+
+**Tech Stack :** GitHub Actions, MySQL 8.0, PHP 8.4, Pest, Docker Compose (dev).
+
+## Global Constraints
+
+- Spec de référence : `docs/superpowers/specs/2026-07-12-tests-sur-mysql-en-ci-design.md`
+- **Ne PAS modifier `phpunit.xml`.** Vérifié : les variables d'environnement du système priment sur ses `<env>`. Le fichier continue de déclarer SQLite (pour le local) et la CI le surcharge sans y toucher.
+- **Vérifié au préalable : les 88 tests passent déjà sur MySQL** (9,3 s, contre 1,4 s sur SQLite). Aucun test n'est à réparer. Si un test échoue sur MySQL, c'est que quelque chose a été cassé — ne le contourne pas, signale-le.
+- La base de test porte un nom **dédié** (`promeb_test`). La suite utilise `RefreshDatabase`, qui **détruit et recrée les tables** : pointer sur la base de développement (`my_event_app`) effacerait les données de travail (30 prestations, 5 factures).
+- Une CI verte ne suffit pas comme preuve : si la connexion retombait silencieusement sur SQLite, elle serait verte **et** aveugle — la situation qu'on veut quitter. Le workflow doit **afficher la connexion réellement utilisée**.
+- Identifiants MySQL du container de dev (`docker-compose.yml`) : base `my_event_app`, utilisateur `laravel`, mot de passe `secret`, root `rootpassword`. Le service `db`, l'applicatif `app`.
+- Commits en français, format `type: description`.
+
+---
+
+### Task 1 : La CI tourne sur MySQL
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: le job `tests` s'exécute contre un service MySQL. La tâche 2 fournit l'équivalent en local.
+
+- [ ] **Step 1: Ajouter le service MySQL et pointer les tests dessus**
+
+Remplacer le contenu de `.github/workflows/ci.yml` par :
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    name: Tests (Pest)
+    runs-on: ubuntu-latest
+
+    # La suite tourne sur MySQL, le moteur de la production.
+    # SQLite (utilisé en local pour la vitesse) résout les cascades et les
+    # contraintes d'intégrité différemment : il a déjà laissé passer deux bugs
+    # de perte de données (cf. PR #22).
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: promeb_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: promeb_test
+      DB_USERNAME: root
+      DB_PASSWORD: root
+
+    steps:
+      - name: Checkout du code
+        uses: actions/checkout@v4
+
+      - name: Installation de PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo, pdo_mysql, pdo_sqlite, mbstring, zip, exif, pcntl, gd, bcmath, intl
+          coverage: none
+
+      - name: Cache des dépendances Composer
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Installation des dépendances Composer
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Préparation de l'environnement
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      # Preuve que la suite tourne bien sur MySQL. Une CI verte ne suffit pas :
+      # si la connexion retombait sur SQLite, elle serait verte ET aveugle.
+      - name: Vérification de la connexion à la base
+        run: php artisan db:show
+
+      - name: Exécution des tests
+        run: php artisan test --testsuite=Feature
+```
+
+Points de conception, à ne pas altérer :
+
+- Le **healthcheck** du service (`mysqladmin ping`) : sans lui, les tests attaquent une base pas encore prête, et la CI échoue une fois sur trois. `--health-retries=10` laisse à MySQL 8 le temps de démarrer (il est lent au premier boot).
+- Le step **`php artisan db:show`** avant les tests : il affiche la connexion et la base réellement utilisées. C'est la preuve exigée par la spec — sans lui, on ne saurait pas distinguer une CI qui teste MySQL d'une CI qui est retombée sur SQLite. Il joue aussi le rôle de garde-fou : si MySQL n'est pas joignable, `db:show` **échoue et fait tomber le job**, au lieu de laisser les tests démarrer sur un autre moteur. La CI ne peut donc pas être verte et aveugle.
+- `DB_HOST` vaut **`127.0.0.1`**, pas `mysql` : le job tourne directement sur le runner (pas dans un container), et le service est exposé sur le port `3306` de l'hôte.
+- `pdo_sqlite` reste installé : il ne coûte rien et sert si un test le demande un jour.
+
+- [ ] **Step 2: Valider la syntaxe YAML localement**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML valide')"`
+Expected: `YAML valide`. Une erreur d'indentation dans un workflow ne se voit qu'une fois poussé — autant l'attraper maintenant.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: fait tourner la suite de tests sur MySQL"
+```
+
+> La vérification réelle de cette tâche se fait **sur la PR** : la CI doit être verte, et le log du step « Vérification de la connexion à la base » doit montrer `mysql` (et non `sqlite`). Le contrôleur du plan s'en assurera après l'ouverture de la PR — c'est indiqué dans la vérification finale.
+
+---
+
+### Task 2 : Lancer la suite sur MySQL en local
+
+**Files:**
+- Create: `bin/test-mysql.sh`
+- Create: `docs/tests.md`
+
+**Interfaces:**
+- Consumes: rien (indépendant de la tâche 1).
+- Produces: `bin/test-mysql.sh`, exécutable, qui lance la suite contre la base MySQL du container de développement.
+
+- [ ] **Step 1: Écrire le script**
+
+Créer `bin/test-mysql.sh` :
+
+```bash
+#!/usr/bin/env bash
+#
+# Lance la suite de tests sur MySQL — le moteur de la production.
+#
+# Par défaut, `php artisan test` tourne sur SQLite en mémoire (rapide, mais il
+# résout les cascades et les contraintes d'intégrité autrement que MySQL : il a
+# déjà laissé passer deux bugs de perte de données). Utilisez ce script dès que
+# vous touchez aux cascades, aux contraintes d'intégrité ou aux suppressions.
+#
+# Nécessite que le container de développement tourne (`docker compose up -d`).
+
+set -euo pipefail
+
+BASE_DE_TEST="promeb_test"
+BASE_DE_DEV="my_event_app"
+
+# Garde-fou : la suite utilise RefreshDatabase, qui DÉTRUIT et recrée les tables.
+# La pointer sur la base de développement effacerait les données de travail.
+if [ "$BASE_DE_TEST" = "$BASE_DE_DEV" ]; then
+    echo "ERREUR : la base de test ne peut pas être la base de développement (${BASE_DE_DEV})." >&2
+    echo "RefreshDatabase détruirait vos données. Abandon." >&2
+    exit 1
+fi
+
+echo "→ Préparation de la base de test « ${BASE_DE_TEST} »…"
+docker compose exec -T db mysql -uroot -prootpassword \
+    -e "CREATE DATABASE IF NOT EXISTS ${BASE_DE_TEST}; GRANT ALL PRIVILEGES ON ${BASE_DE_TEST}.* TO 'laravel'@'%'; FLUSH PRIVILEGES;" 2>/dev/null
+
+echo "→ Exécution de la suite sur MySQL…"
+docker compose exec -T \
+    -e HOME=/tmp \
+    -e DB_CONNECTION=mysql \
+    -e DB_HOST=db \
+    -e DB_PORT=3306 \
+    -e DB_DATABASE="${BASE_DE_TEST}" \
+    -e DB_USERNAME=laravel \
+    -e DB_PASSWORD=secret \
+    app php artisan test --testsuite=Feature "$@"
+```
+
+Notes :
+
+- `-e HOME=/tmp` est nécessaire : sans un HOME inscriptible, les commandes artisan
+  échouent dans ce container.
+- `DB_HOST=db` (et non `127.0.0.1`) : le script exécute la commande **dans** le
+  container `app`, qui joint la base par le réseau Docker.
+- `"$@"` transmet les arguments : `bin/test-mysql.sh tests/Feature/MonTest.php`
+  fonctionne.
+- La garde comparant les deux noms de base peut sembler tautologique puisque les
+  deux valeurs sont écrites juste au-dessus — c'est voulu : elle protège contre
+  la modification distraite d'une seule des deux constantes.
+
+- [ ] **Step 2: Rendre le script exécutable**
+
+Run: `chmod +x bin/test-mysql.sh`
+
+- [ ] **Step 3: Vérifier que le script tourne, et qu'il ne touche pas la base de dev**
+
+D'abord, relever l'état de la base de développement :
+
+Run: `docker compose exec -T -e HOME=/tmp app php artisan tinker --execute="echo 'prestations: ' . App\Models\Prestation::count() . ' | factures: ' . App\Models\Facture::count();"`
+Expected: affiche le nombre de prestations et de factures (attendu : 30 et 5). **Note ces valeurs.**
+
+Puis lancer le script :
+
+Run: `./bin/test-mysql.sh`
+Expected: **88 tests verts**, en ~10 s (nettement plus lent que les 1,4 s de SQLite — c'est le signe que MySQL est bien utilisé).
+
+Puis re-vérifier la base de développement :
+
+Run: `docker compose exec -T -e HOME=/tmp app php artisan tinker --execute="echo 'prestations: ' . App\Models\Prestation::count() . ' | factures: ' . App\Models\Facture::count();"`
+Expected: **exactement les mêmes valeurs qu'avant**. Si elles ont changé, le script a détruit les données de développement : c'est un échec grave, arrête-toi et signale-le.
+
+- [ ] **Step 4: Écrire la documentation**
+
+Créer `docs/tests.md` :
+
+```markdown
+# Lancer les tests
+
+## Par défaut — SQLite en mémoire (rapide)
+
+```bash
+php artisan test --testsuite=Feature
+```
+
+Environ 1,4 s. C'est ce que fait `phpunit.xml`, et c'est ce qu'il faut pour itérer.
+
+> `php artisan test` **sans** `--testsuite=Feature` échoue : `phpunit.xml` déclare
+> une suite `Unit` alors que `tests/Unit/` n'existe pas.
+
+## Sur MySQL — le moteur de la production (fidèle)
+
+```bash
+./bin/test-mysql.sh
+```
+
+Environ 10 s. Nécessite que le container de développement tourne
+(`docker compose up -d`). La suite s'exécute contre une base dédiée
+(`promeb_test`), jamais contre la base de développement.
+
+**Utilisez-le dès que vous touchez aux cascades, aux contraintes d'intégrité ou
+aux suppressions.** SQLite et MySQL ne les résolvent pas de la même façon, et
+c'est précisément là que SQLite ment : il a déjà laissé passer deux bugs de perte
+de données (cf. PR #22), que seule une exécution sur MySQL a révélés.
+
+## En intégration continue
+
+La CI tourne **sur MySQL** — voir `.github/workflows/ci.yml`. Un test peut donc
+passer en local (SQLite) et casser en CI (MySQL) : c'est le rôle du filet, et il
+bloque avant le merge.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/test-mysql.sh docs/tests.md
+git commit -m "test: script pour lancer la suite sur MySQL en local"
+```
+
+---
+
+## Vérification finale
+
+- [ ] `php artisan test --testsuite=Feature` — 88 tests verts (SQLite, inchangé).
+- [ ] `./bin/test-mysql.sh` — 88 tests verts (MySQL), et la base de développement est intacte.
+- [ ] **Sur la PR** : la CI est verte, et le log du step « Vérification de la connexion à la base » affiche bien `mysql` — pas `sqlite`. C'est la preuve que le filet est réellement en place ; sans elle, on aurait une CI verte et toujours aveugle.

--- a/docs/superpowers/specs/2026-07-12-tests-sur-mysql-en-ci-design.md
+++ b/docs/superpowers/specs/2026-07-12-tests-sur-mysql-en-ci-design.md
@@ -1,0 +1,106 @@
+# Faire tourner la suite de tests sur MySQL en CI
+
+Date : 2026-07-12
+
+## Problème
+
+`phpunit.xml` fait tourner la suite sur **SQLite en mémoire** ; la production est
+sur **MySQL**. Les deux moteurs ne traitent pas les cascades ni les contraintes
+d'intégrité de la même façon.
+
+**Cette divergence a déjà laissé passer deux bugs réels**, dans une seule branche
+(PR #22, 2026-07-12) :
+
+1. Une migration passant `prestations.client_id` / `taux_horaire_id` en `RESTRICT`
+   cassait la suppression d'un `User` **sur MySQL** (`SQLSTATE 23000 / 1451` :
+   InnoDB supprime la ligne `clients` avant la ligne `prestations` qui la
+   référence). Sur SQLite, l'ordre de résolution diffère et le test passait — un
+   faux négatif structurel.
+2. Le correctif de ce bug réintroduisait une perte de données, et là encore le
+   test SQLite était vert.
+
+Les deux n'ont été trouvés qu'en exerçant la vraie base MySQL à la main. **La CI
+est aveugle à cette famille de bugs**, et c'est précisément la famille qui détruit
+des données.
+
+## Décisions
+
+**La CI tourne sur MySQL ; le développement local reste sur SQLite.** Trois options
+ont été pesées :
+
+- *MySQL partout, y compris en local* — plus aucune divergence, mais chaque
+  lancement passe de 1,4 s à 9,3 s et exige que Docker tourne. Alourdit
+  l'itération, notamment sur le front.
+- *Les deux moteurs en CI* — double le temps de CI pour un bénéfice quasi nul :
+  c'est MySQL qui compte, SQLite n'est qu'une commodité de développement.
+- **Retenu : CI sur MySQL, local sur SQLite.** La CI devient le filet fidèle à la
+  production ; l'itération locale reste instantanée.
+
+**Conséquence assumée** : un test peut passer en local et casser en CI. C'est le
+rôle du filet, et il bloque avant le merge.
+
+**Aucune modification de `phpunit.xml`.** Vérifié : les variables d'environnement
+du système **priment** sur les `<env>` de `phpunit.xml`. Lancer la suite avec
+`DB_CONNECTION=mysql …` la fait tourner sur MySQL sans toucher au fichier, qui
+continue de déclarer SQLite pour le développement local. C'est ce qui rend le
+changement petit.
+
+**Vérifié au préalable, et c'est ce qui débloque le sujet** : les **88 tests
+passent déjà sur MySQL** (9,3 s contre 1,4 s sur SQLite). Aucun test n'est à
+réparer.
+
+## Conception
+
+### Le workflow
+
+`.github/workflows/ci.yml`, job `tests` :
+
+- Un **service `mysql:8.0`**, avec un *healthcheck* (`mysqladmin ping`). Sans lui,
+  les tests attaqueraient une base pas encore prête — la cause classique d'une CI
+  qui échoue une fois sur trois.
+- L'extension **`pdo_mysql`** ajoutée à la liste installée par `setup-php`
+  (`pdo_sqlite` reste : elle ne coûte rien et sert si un test la demande un jour).
+- Le step d'exécution reçoit les variables `DB_CONNECTION`, `DB_HOST`, `DB_PORT`,
+  `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` pointant sur le service.
+
+La base de test du service porte un nom dédié (`promeb_test`) : la suite utilise
+`RefreshDatabase`, qui détruit et recrée les tables à chaque exécution.
+
+### Le script local
+
+`bin/test-mysql.sh` encapsule la commande Docker qui lance la suite contre la base
+MySQL du container de développement, dans une **base séparée** (`promeb_test`), et
+la crée si elle n'existe pas.
+
+Il ne doit jamais pointer sur la base de développement (`my_event_app`) :
+`RefreshDatabase` effacerait les données de travail. Le script doit donc refuser de
+tourner si le nom de base n'est pas celui de test — une garde explicite, pas une
+convention.
+
+### La documentation
+
+`docs/tests.md`, court : quelle commande lance quoi, et **quand** utiliser MySQL en
+local — dès qu'on touche aux cascades, aux contraintes d'intégrité ou aux
+suppressions. C'est là que SQLite ment, et c'est la seule chose que le lecteur doit
+retenir.
+
+## Tests
+
+Le livrable est une configuration : sa vérification passe par l'exécution.
+
+- La CI de la PR doit être **verte**, et son log doit montrer que la suite a bien
+  tourné sur **MySQL** — pas sur SQLite. Le temps d'exécution le trahit (≈ 9 s
+  contre 1,4 s), mais ce n'est pas une preuve suffisante : le workflow affichera
+  explicitement la connexion utilisée (`php artisan db:show` avant les tests, ou
+  équivalent).
+- **La preuve que le filet fonctionne** : la CI doit échouer si les tests tournent
+  sur un moteur qui ment. Concrètement, on vérifie que le job échoue quand la base
+  MySQL n'est pas joignable, plutôt que de retomber silencieusement sur SQLite.
+- `bin/test-mysql.sh` doit tourner et donner 88 tests verts, sans altérer la base
+  de développement (vérifier son contenu avant / après).
+
+## Hors périmètre
+
+- Faire tourner le développement local sur MySQL.
+- Le workflow de déploiement (`deploy.yml`), inchangé.
+- Les tests front (le projet n'en a pas).

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,33 @@
+# Lancer les tests
+
+## Par défaut — SQLite en mémoire (rapide)
+
+```bash
+php artisan test --testsuite=Feature
+```
+
+Environ 1,4 s. C'est ce que fait `phpunit.xml`, et c'est ce qu'il faut pour itérer.
+
+> `php artisan test` **sans** `--testsuite=Feature` échoue : `phpunit.xml` déclare
+> une suite `Unit` alors que `tests/Unit/` n'existe pas.
+
+## Sur MySQL — le moteur de la production (fidèle)
+
+```bash
+./bin/test-mysql.sh
+```
+
+Environ 10 s. Nécessite que le container de développement tourne
+(`docker compose up -d`). La suite s'exécute contre une base dédiée
+(`promeb_test`), jamais contre la base de développement.
+
+**Utilisez-le dès que vous touchez aux cascades, aux contraintes d'intégrité ou
+aux suppressions.** SQLite et MySQL ne les résolvent pas de la même façon, et
+c'est précisément là que SQLite ment : il a déjà laissé passer deux bugs de perte
+de données (cf. PR #22), que seule une exécution sur MySQL a révélés.
+
+## En intégration continue
+
+La CI tourne **sur MySQL** — voir `.github/workflows/ci.yml`. Un test peut donc
+passer en local (SQLite) et casser en CI (MySQL) : c'est le rôle du filet, et il
+bloque avant le merge.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -19,15 +19,44 @@ Environ 1,4 s. C'est ce que fait `phpunit.xml`, et c'est ce qu'il faut pour ité
 
 Environ 10 s. Nécessite que le container de développement tourne
 (`docker compose up -d`). La suite s'exécute contre une base dédiée
-(`promeb_test`), jamais contre la base de développement.
+(`promeb_test`), et le script vérifie — avant de lancer quoi que ce soit —
+que c'est bien cette base que Laravel résout effectivement, jamais la base de
+développement.
 
 **Utilisez-le dès que vous touchez aux cascades, aux contraintes d'intégrité ou
 aux suppressions.** SQLite et MySQL ne les résolvent pas de la même façon, et
 c'est précisément là que SQLite ment : il a déjà laissé passer deux bugs de perte
 de données (cf. PR #22), que seule une exécution sur MySQL a révélés.
 
+### Le garde-fou : vérifier la base effective, pas une variable demandée
+
+`RefreshDatabase` détruit et recrée les tables. Un script naïf qui se
+contenterait de comparer deux constantes, ou de supposer que
+`-e DB_DATABASE=promeb_test` passé à `docker compose exec` suffit, n'est
+**pas** protégé : dès qu'un `bootstrap/cache/config.php` existe dans le
+container (généré par exemple par `php artisan config:cache` ou
+`php artisan optimize`, une commande banale), Laravel ignore les variables
+d'environnement passées à l'exécution et résout la base figée dans ce cache —
+potentiellement la base de développement.
+
+`bin/test-mysql.sh` ne suppose donc rien : il demande à Laravel, depuis
+l'intérieur du container, quelle base il résout *effectivement*
+(`config('database.connections.mysql.database')`) et refuse de continuer si
+elle diffère de `promeb_test`. Si ce garde-fou se déclenche, videz le config
+cache (`docker compose exec app php artisan config:clear`) et relancez.
+
 ## En intégration continue
 
 La CI tourne **sur MySQL** — voir `.github/workflows/ci.yml`. Un test peut donc
 passer en local (SQLite) et casser en CI (MySQL) : c'est le rôle du filet, et il
 bloque avant le merge.
+
+Le step `db:show` du workflow vérifie la connectivité MySQL, mais tourne dans
+un processus séparé de PHPUnit : il ne peut pas détecter un `phpunit.xml` qui
+forcerait SQLite (`force="true"` sur `<env name="DB_CONNECTION" value="sqlite"/>`)
+et rendrait la CI verte tout en testant silencieusement le mauvais moteur.
+`tests/Feature/MoteurBaseTest.php` comble ce trou : il vérifie le moteur
+*depuis l'intérieur du processus PHPUnit*, la seule preuve qui vaille. Il ne
+s'exécute que si la variable `CI` (définie par GitHub Actions, jamais touchée
+par `phpunit.xml`) vaut `true` — il reste donc silencieusement skip en local
+sur SQLite.

--- a/tests/Feature/MoteurBaseTest.php
+++ b/tests/Feature/MoteurBaseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+
+// La CI fait tourner la suite sur MySQL exprès (voir .github/workflows/ci.yml
+// et docs/tests.md) : SQLite résout les cascades et les contraintes
+// d'intégrité différemment, et a déjà laissé passer deux bugs de perte de
+// données (cf. PR #22). Le step `db:show` du workflow ne suffit pas à
+// garantir ça : il tourne dans un processus séparé de PHPUnit, alors que
+// c'est phpunit.xml (à l'intérieur du processus PHPUnit) qui décide de la
+// connexion réellement utilisée par les tests. Si quelqu'un ajoute
+// `force="true"` à `<env name="DB_CONNECTION" value="sqlite"/>`, `db:show`
+// resterait vert (il voit MySQL) alors que PHPUnit tournerait, lui, sur
+// SQLite : la CI serait verte et aveugle.
+//
+// Ce test vérifie donc le moteur *depuis l'intérieur du processus PHPUnit*,
+// la seule preuve qui vaille.
+//
+// Condition de déclenchement : la variable `CI`, que GitHub Actions définit
+// toujours à `true` pour tout job — jamais touchée par phpunit.xml. On ne
+// peut pas se fier à `DB_CONNECTION` pour décider si on est censé tester
+// MySQL : c'est précisément la variable que le scénario attaqué (force="true")
+// détourne, donc l'utiliser comme condition de déclenchement la rendrait
+// aveugle à l'attaque qu'elle est censée détecter. `CI` reste vraie même si
+// PHPUnit est piégé par un `force="true"` sur DB_CONNECTION.
+it('tourne bien sur MySQL en CI, jamais un fallback SQLite silencieux', function () {
+    if (getenv('CI') !== 'true') {
+        $this->markTestSkipped('Hors CI : le développement local tourne sciemment sur SQLite (voir docs/tests.md).');
+    }
+
+    expect(DB::connection()->getDriverName())->toBe('mysql');
+});


### PR DESCRIPTION
`phpunit.xml` fait tourner la suite sur **SQLite en mémoire**, alors que la production est sur **MySQL**. Les deux moteurs ne résolvent pas les cascades ni les contraintes d'intégrité de la même façon.

**Cette divergence a déjà laissé passer deux bugs de perte de données**, dans une seule branche (PR #22) :

1. Une migration passant `prestations.client_id` / `taux_horaire_id` en `RESTRICT` cassait la suppression d'un `User` **sur MySQL** (`SQLSTATE 23000`). Sur SQLite, l'ordre de résolution des cascades diffère : le test passait.
2. Le correctif de ce bug réintroduisait une perte de données — et là encore, le test SQLite était vert.

Les deux n'ont été trouvés qu'en exerçant MySQL à la main. **La CI était aveugle à la famille de bugs qui détruit des données.**

## Ce que fait cette PR

| Fichier | Changement |
|---|---|
| `.github/workflows/ci.yml` | Service `mysql:8.0` (avec healthcheck), extension `pdo_mysql`, variables `DB_*`, et `php artisan db:show` avant les tests |
| `bin/test-mysql.sh` | Lance la suite sur MySQL en local, contre une base dédiée `promeb_test` |
| `tests/Feature/MoteurBaseTest.php` | Vérifie le moteur **depuis l'intérieur** du processus PHPUnit |
| `docs/tests.md` | Quelle commande lance quoi, et quand utiliser MySQL en local |

**`phpunit.xml` n'est pas touché** : les variables d'environnement du système priment sur ses `<env>` — vérifié dans les sources de PHPUnit et de Dotenv, pas supposé. Le développement local continue donc de tourner sur SQLite (1,4 s), et la CI sur MySQL (~9 s).

Les 88 tests passaient déjà sur MySQL : aucun n'a eu besoin d'être réparé.

## Deux failles trouvées en revue, et corrigées

**Le script pouvait détruire les données de développement.** Son garde-fou comparait deux constantes, alors que ce qui décide réellement de la base cible, c'est la préséance des variables `-e` sur le `.env` du container. Or cette préséance **tombe dès qu'un `bootstrap/cache/config.php` existe** :

```
Sans cache :  -e DB_DATABASE=promeb_test  →  base = promeb_test
Avec cache :  -e DB_DATABASE=promeb_test  →  base = my_event_app  ☠️
```

Un `php artisan optimize` lancé un jour dans le container suffisait : le script aurait affiché « base de test promeb_test », puis fait un `migrate:fresh` sur la base de développement. Le script **vérifie désormais la base effectivement résolue par Laravel**, et refuse de tourner sinon — testé en générant réellement un config cache.

**`db:show` ne prouvait pas ce qu'on croyait.** Il tourne dans un processus distinct de PHPUnit — or c'est *dans* le processus PHPUnit que `phpunit.xml` injecte SQLite. Un `force="true"` ajouté à cette ligne aurait donné une CI verte tournant sur SQLite : verte **et aveugle**, exactement ce que cette PR existe pour supprimer. `MoteurBaseTest` vérifie donc le moteur depuis l'intérieur du processus de test, conditionné à `CI=true` (et non à `DB_CONNECTION`, qui est justement la variable qu'un tel détournement manipulerait).

## Vérifications

- `./bin/test-mysql.sh` : 88 tests verts sur MySQL, **base de développement intacte** (30 prestations, 5 factures, avant comme après — checksums de tables identiques).
- Garde-fou éprouvé : avec un config cache présent, le script refuse de tourner au lieu de détruire la base.
- `MoteurBaseTest` échoue bien si l'on simule une CI retombée sur SQLite (`-'mysql' +'sqlite'`).
- Suite locale (SQLite) : 88 passés, 1 ignoré (le test de moteur, inactif hors CI).

## Note

`deploy.yml` étant conditionné au succès de la CI, une instabilité du service MySQL bloquerait désormais les déploiements. Le healthcheck (`mysqladmin ping` en TCP, 10 tentatives) est conçu pour l'éviter.

Spec et plan : `docs/superpowers/specs/2026-07-12-tests-sur-mysql-en-ci-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj