### PR TITLE
Facturer des prestations de clients différents renvoyait un 500

### DIFF
--- a/app/Services/FactureService.php
+++ b/app/Services/FactureService.php
@@ -6,7 +6,6 @@ use App\Enums\FactureStatut;
 use App\Models\Facture;
 use App\Models\Prestation;
 use Barryvdh\DomPDF\Facade\Pdf;
-use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -42,10 +41,14 @@ class FactureService extends BaseService
                     ]);
                 }
 
-                // Vérifier si toutes les prestations appartiennent au même client
+                // Une facture ne peut concerner qu'un seul client.
+                // ValidationException (et non Exception) : c'est une erreur métier,
+                // que l'utilisateur doit lire — pas un plantage serveur en 500.
                 $clients = $prestations->groupBy('client_id');
                 if ($clients->count() > 1) {
-                    throw new Exception("Toutes les prestations doivent appartenir au même client.");
+                    throw ValidationException::withMessages([
+                        'prestations' => 'Toutes les prestations doivent concerner le même client. Créez une facture par client.',
+                    ]);
                 }
 
                 $heuresTotal = $prestations->sum('heures');

--- a/tests/Feature/FactureClientsDifferentsTest.php
+++ b/tests/Feature/FactureClientsDifferentsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Facture;
+use App\Models\Prestation;
+use App\Models\TauxHoraire;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Une facture ne peut concerner qu'un seul client. Le garde-fou existait déjà,
+ * mais il levait une Exception générique : l'utilisateur recevait un 500 —
+ * un plantage serveur — au lieu d'une erreur métier lisible.
+ */
+it('refuse de facturer des prestations de clients differents, avec un message lisible', function () {
+    $user = User::factory()->create();
+    $taux = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 50]);
+
+    $clientA = Client::factory()->create(['user_id' => $user->id]);
+    $clientB = Client::factory()->create(['user_id' => $user->id]);
+
+    $prestationA = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $clientA->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+        'heures'          => 10,
+    ]);
+
+    $prestationB = Prestation::factory()->create([
+        'user_id'         => $user->id,
+        'client_id'       => $clientB->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+        'heures'          => 10,
+    ]);
+
+    $response = $this->actingAs($user)->postJson('/api/factures', [
+        'prestations' => [$prestationA->id, $prestationB->id],
+    ]);
+
+    // Une erreur métier, pas un plantage serveur.
+    $response->assertStatus(422);
+
+    // Le message doit être exploitable par l'utilisateur, et porté par la clé
+    // « prestations » pour que le front l'affiche au bon endroit.
+    expect($response->json('errors.prestations.0'))->toContain('même client');
+
+    // Le garde-fou fonctionnait déjà : rien ne doit avoir été créé ni rattaché.
+    expect(Facture::count())->toBe(0);
+    expect($prestationA->fresh()->facture_id)->toBeNull();
+    expect($prestationB->fresh()->facture_id)->toBeNull();
+});
+
+it('facture normalement plusieurs prestations d\'un meme client', function () {
+    $user   = User::factory()->create();
+    $taux   = TauxHoraire::factory()->create(['user_id' => $user->id, 'taux' => 50]);
+    $client = Client::factory()->create(['user_id' => $user->id]);
+
+    $prestations = Prestation::factory()->count(3)->create([
+        'user_id'         => $user->id,
+        'client_id'       => $client->id,
+        'taux_horaire_id' => $taux->id,
+        'facture_id'      => null,
+        'heures'          => 10,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson('/api/factures', ['prestations' => $prestations->pluck('id')->all()])
+        ->assertCreated();
+
+    expect((float) Facture::first()->montant_total)->toBe(1500.0);
+});


### PR DESCRIPTION
Créer une facture avec des prestations relevant de **clients différents** remontait en **HTTP 500** — un plantage serveur, avec un corps de réponse vide.

Reproduit contre l'API :

```
POST /api/factures avec 2 prestations de 2 clients distincts
  → Statut HTTP : 500
  → Corps : vide
  → Factures en base : 0
  → Prestations rattachées : aucune
```

**Le garde-fou métier fonctionnait déjà** : rien n'était créé, rien n'était rattaché. Seule sa *présentation* était fautive — l'utilisateur voyait « erreur serveur » là où il devait lire « toutes les prestations doivent concerner le même client ».

## La cause

`FactureService::create` levait une `Exception` générique :

```php
if ($clients->count() > 1) {
    throw new Exception("Toutes les prestations doivent appartenir au même client.");
}
```

`BaseService::handleExceptions` la journalise puis la **relance telle quelle**. Sans `renderable()` configuré, Laravel rend une `Exception` nue en 500.

Or le pattern correct était **dix lignes plus haut** : le garde-fou voisin, qui vérifie que les prestations appartiennent bien à l'utilisateur, lève une `ValidationException` et produit un 422 propre. La seule différence entre les deux garde-fous était le type d'exception.

## Le correctif

Une `ValidationException` sur la clé `prestations`, comme son voisin. Le message remonte automatiquement en toast dans le front, via le store — aucun changement front nécessaire.

L'import `use Exception;` devenu orphelin est retiré.

## Vérifications

- Le test échouait bien avant le correctif : `Expected response status code [422] but received 500`.
- Le test vérifie aussi qu'aucune facture n'est créée et qu'aucune prestation n'est rattachée — le comportement correct qui existait déjà ne doit pas régresser.
- Le cas nominal (plusieurs prestations d'un **même** client) est couvert : facture créée, montant juste.
- **90 tests verts sur les deux moteurs** : SQLite (2,0 s) et MySQL (9,6 s, via `./bin/test-mysql.sh`).

Premier changement validé de bout en bout par la nouvelle CI MySQL et les deux suites de tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj