### PR TITLE
L'état de chargement du paiement était partagé par toutes les factures

### DIFF
--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,36 +1,36 @@
 {
-  "_ClientFormModal-GCgMqq6G.js": {
-    "file": "assets/ClientFormModal-GCgMqq6G.js",
+  "_ClientFormModal-Cm-EfG_t.js": {
+    "file": "assets/ClientFormModal-Cm-EfG_t.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js",
-      "_clients-C3dYXxt1.js"
+      "_clients-DpefF64T.js"
     ]
   },
-  "_FactureFormModal-DZA4aDsH.js": {
-    "file": "assets/FactureFormModal-DZA4aDsH.js",
+  "_FactureFormModal-B2GyBTGq.js": {
+    "file": "assets/FactureFormModal-B2GyBTGq.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-D9cDnY7n.js"
+      "_prestations-DGNn47DW.js"
     ]
   },
-  "_TauxHoraireFormModal-8wvQDqp3.js": {
-    "file": "assets/TauxHoraireFormModal-8wvQDqp3.js",
+  "_TauxHoraireFormModal-Dou4ZpRI.js": {
+    "file": "assets/TauxHoraireFormModal-Dou4ZpRI.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_clients-C3dYXxt1.js": {
-    "file": "assets/clients-C3dYXxt1.js",
+  "_clients-DpefF64T.js": {
+    "file": "assets/clients-DpefF64T.js",
     "name": "clients",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-D9cDnY7n.js": {
-    "file": "assets/prestations-D9cDnY7n.js",
+  "_prestations-DGNn47DW.js": {
+    "file": "assets/prestations-DGNn47DW.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -43,7 +43,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-CJYZKmOp.css",
+    "file": "assets/app-BGUOi8rf.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -56,7 +56,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-Dwq1HFlA.js",
+    "file": "assets/app-Cs3DjPVY.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -74,54 +74,54 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-D5jk39UI.js",
+    "file": "assets/Client-ZG_AYEza.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_clients-C3dYXxt1.js",
-      "_ClientFormModal-GCgMqq6G.js"
+      "_clients-DpefF64T.js",
+      "_ClientFormModal-Cm-EfG_t.js"
     ],
     "css": [
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-CDIq0OhC.js",
+    "file": "assets/Dashboard-DB9NDV7r.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-DZA4aDsH.js",
-      "_prestations-D9cDnY7n.js"
+      "_FactureFormModal-B2GyBTGq.js",
+      "_prestations-DGNn47DW.js"
     ],
     "css": [
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture--loJcITR.js",
+    "file": "assets/Facture-gfWM_FzG.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-DZA4aDsH.js",
-      "_clients-C3dYXxt1.js",
-      "_prestations-D9cDnY7n.js"
+      "_FactureFormModal-B2GyBTGq.js",
+      "_clients-DpefF64T.js",
+      "_prestations-DGNn47DW.js"
     ],
     "css": [
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-BDDsIwON.js",
+    "file": "assets/Login-C-urmUKZ.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -129,11 +129,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-BXHRu_Nv.js",
+    "file": "assets/NotFound-ji_tXthn.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -141,27 +141,27 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-DZe5ymES.js",
+    "file": "assets/Prestation-q4Et_QXf.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-D9cDnY7n.js",
-      "_clients-C3dYXxt1.js",
-      "_TauxHoraireFormModal-8wvQDqp3.js",
-      "_ClientFormModal-GCgMqq6G.js"
+      "_prestations-DGNn47DW.js",
+      "_clients-DpefF64T.js",
+      "_TauxHoraireFormModal-Dou4ZpRI.js",
+      "_ClientFormModal-Cm-EfG_t.js"
     ],
     "css": [
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-DLbfgaer.js",
+    "file": "assets/Profile-B1iRPKy7.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -170,11 +170,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-CWZQoADd.js",
+    "file": "assets/PwaStatus-C6sHO--g.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -183,23 +183,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-DvLAqn10.js",
+    "file": "assets/TauxHoraire-Df2ZzpqW.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-8wvQDqp3.js"
+      "_TauxHoraireFormModal-Dou4ZpRI.js"
     ],
     "css": [
-      "assets/app-CJYZKmOp.css"
+      "assets/app-BGUOi8rf.css"
     ]
   }
 }

--- a/resources/js/components/dashboard/FacturesModal.vue
+++ b/resources/js/components/dashboard/FacturesModal.vue
@@ -36,12 +36,12 @@
                 📄 Voir PDF
               </button>
 
-              <button 
-                v-if="invoice.statut === 'en_attente_paiement'" 
-                @click="markAsPaid(invoice)" 
-                :disabled="loading.paid"
+              <button
+                v-if="invoice.statut === 'en_attente_paiement'"
+                @click="markAsPaid(invoice)"
+                :disabled="enCoursDePaiement(invoice)"
                 class="btn-action bg-green-500 disabled:opacity-50">
-              <span v-if="loading.paid" class="animate-spin border-4 border-white border-t-transparent rounded-full w-4 h-4"></span>
+              <span v-if="enCoursDePaiement(invoice)" class="animate-spin border-4 border-white border-t-transparent rounded-full w-4 h-4"></span>
               ✅ Payé
           </button>
             </div>
@@ -127,6 +127,11 @@ const { loading } = storeToRefs(invoiceStore)
 const { paid } = invoiceStore
 
 const showPdfModal = ref(null);
+
+// Chaque facture n'observe que SON propre état de chargement : la clé du store
+// est indexée par facture. Avec une clé unique, marquer une facture payée
+// désactivait le bouton de toutes les autres lignes en attente de paiement.
+const enCoursDePaiement = (invoice) => loading.value[`paid_${invoice.id}`] === true;
 
 // Calcul du total des heures et du montant HT
 const totalHeures = computed(() => {

--- a/resources/js/components/factures/FactureListItem.vue
+++ b/resources/js/components/factures/FactureListItem.vue
@@ -63,10 +63,10 @@
         <button
           v-if="invoice.statut === 'en_attente_paiement'"
           @click="markAsPaid(invoice)"
-          :disabled="loading.paid"
+          :disabled="enCoursDePaiement"
           class="btn-action bg-green-500 disabled:opacity-50 flex-1 lg:flex-none justify-center"
         >
-          <span v-if="loading.paid" class="animate-spin border-2 border-white border-t-transparent rounded-full w-3 h-3"></span>
+          <span v-if="enCoursDePaiement" class="animate-spin border-2 border-white border-t-transparent rounded-full w-3 h-3"></span>
           <span v-else>✅</span>
           <span>Payé</span>
         </button>
@@ -115,6 +115,11 @@ const props = defineProps({
     required: true,
   },
 });
+
+// Chaque ligne n'observe que SON propre état de chargement : la clé du store est
+// indexée par facture. Avec une clé unique, cliquer « Payé » sur une facture
+// désactivait le bouton de toutes les autres lignes en attente de paiement.
+const enCoursDePaiement = computed(() => loading.value[`paid_${props.invoice.id}`] === true);
 
 const estDeplie = ref(false);
 const showDeleteModal = ref(false);

--- a/resources/js/stores/factures.js
+++ b/resources/js/stores/factures.js
@@ -182,7 +182,10 @@ export const useInvoicesStore = defineStore('invoices', () => {
 
   async function paid(invoiceId) {
     return apiCall({
-      operation: "paid",
+      // La clé est indexée par facture : une clé unique ("paid") ferait réagir
+      // le bouton de TOUTES les lignes en attente de paiement, pas seulement
+      // celle sur laquelle on a cliqué.
+      operation: `paid_${invoiceId}`,
       request: () => axios.patch(`/api/factures/${invoiceId}/paid`),
       onSuccess: (response) => {
         if (dashboardStore.dashboardData) {


### PR DESCRIPTION
Marquer une facture comme payée désactivait le bouton « Payé » et lançait le spinner sur **toutes** les lignes en attente de paiement, pas seulement celle sur laquelle on avait cliqué.

## La cause

`resources/js/stores/factures.js` écrivait `loading['paid']` — **une clé unique, partagée par toutes les factures** :

```js
function setLoading(operation, state) {
  loading.value[operation] = state;   // operation = "paid", pour toutes
}
```

Et chaque ligne lisait ce même booléen (`:disabled="loading.paid"`). Toutes les instances observaient donc le même état.

Le défaut préexistait à la refonte de l'onglet Factures, mais la liste dense affiche dix lignes là où il y avait trois cartes : il est devenu criant.

## Le correctif

La clé est indexée par facture — `paid_<id>` — donc chaque ligne n'observe que son propre état.

**Deux composants appelaient `paid()`, pas un seul.** Outre `FactureListItem` (la liste), `FacturesModal` du dashboard lisait la même clé globale, avec le même bug — et il aurait été **cassé silencieusement** par le changement de clé si je ne l'avais pas corrigé : son bouton n'aurait plus jamais affiché d'état de chargement. Les deux sont traités.

## Vérifications

- Plus aucun lecteur de `loading.paid` dans `resources/js/` (vérifié par recherche).
- Les deux seuls appelants de `paid()` sont corrigés.
- `npm run build` passe ; la clé `paid_` est bien présente dans les bundles compilés du Dashboard et des Factures.
- Backend inchangé : 90 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj