### PR TITLE
Création de facture : choisir le client, puis ses prestations

### DIFF
--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,36 +1,36 @@
 {
-  "_ClientFormModal-BsVzwJZl.js": {
-    "file": "assets/ClientFormModal-BsVzwJZl.js",
+  "_ClientFormModal-CslBenG2.js": {
+    "file": "assets/ClientFormModal-CslBenG2.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js",
-      "_clients-DMKmMIbs.js"
+      "_clients-5-rvP3_G.js"
     ]
   },
-  "_FactureFormModal-C8wEgc1N.js": {
-    "file": "assets/FactureFormModal-C8wEgc1N.js",
+  "_FactureFormModal-Ds50iCJK.js": {
+    "file": "assets/FactureFormModal-Ds50iCJK.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-Dym4sfZg.js"
+      "_prestations-Cnu0E0yz.js"
     ]
   },
-  "_TauxHoraireFormModal-C4oCDvWp.js": {
-    "file": "assets/TauxHoraireFormModal-C4oCDvWp.js",
+  "_TauxHoraireFormModal-CkS2Rhz6.js": {
+    "file": "assets/TauxHoraireFormModal-CkS2Rhz6.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_clients-DMKmMIbs.js": {
-    "file": "assets/clients-DMKmMIbs.js",
+  "_clients-5-rvP3_G.js": {
+    "file": "assets/clients-5-rvP3_G.js",
     "name": "clients",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-Dym4sfZg.js": {
-    "file": "assets/prestations-Dym4sfZg.js",
+  "_prestations-Cnu0E0yz.js": {
+    "file": "assets/prestations-Cnu0E0yz.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -56,7 +56,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-BiD3PCeJ.js",
+    "file": "assets/app-BbqTxuXd.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -78,50 +78,50 @@
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-N4HQ2m-z.js",
+    "file": "assets/Client-jWi3xnWq.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_clients-DMKmMIbs.js",
-      "_ClientFormModal-BsVzwJZl.js"
+      "_clients-5-rvP3_G.js",
+      "_ClientFormModal-CslBenG2.js"
     ],
     "css": [
       "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-CuMWxa7J.js",
+    "file": "assets/Dashboard-LTq4XsTF.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-C8wEgc1N.js",
-      "_prestations-Dym4sfZg.js"
+      "_FactureFormModal-Ds50iCJK.js",
+      "_prestations-Cnu0E0yz.js"
     ],
     "css": [
       "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-B35D7ntP.js",
+    "file": "assets/Facture-BNooromo.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-C8wEgc1N.js",
-      "_clients-DMKmMIbs.js",
-      "_prestations-Dym4sfZg.js"
+      "_FactureFormModal-Ds50iCJK.js",
+      "_clients-5-rvP3_G.js",
+      "_prestations-Cnu0E0yz.js"
     ],
     "css": [
       "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-BWmqAIA1.js",
+    "file": "assets/Login-DuqdPO5D.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -133,7 +133,7 @@
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-C35Uxrb6.js",
+    "file": "assets/NotFound-Qo4QBkW8.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -145,23 +145,23 @@
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-DJwFlKGg.js",
+    "file": "assets/Prestation-iqURn9_t.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-Dym4sfZg.js",
-      "_clients-DMKmMIbs.js",
-      "_TauxHoraireFormModal-C4oCDvWp.js",
-      "_ClientFormModal-BsVzwJZl.js"
+      "_prestations-Cnu0E0yz.js",
+      "_clients-5-rvP3_G.js",
+      "_TauxHoraireFormModal-CkS2Rhz6.js",
+      "_ClientFormModal-CslBenG2.js"
     ],
     "css": [
       "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-Dv9jlFYA.js",
+    "file": "assets/Profile-DKbBjRD-.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -174,7 +174,7 @@
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-DKVEXbdS.js",
+    "file": "assets/PwaStatus-LkcvwGcU.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -190,13 +190,13 @@
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-BHxB0IeN.js",
+    "file": "assets/TauxHoraire-BG5ykEAL.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-C4oCDvWp.js"
+      "_TauxHoraireFormModal-CkS2Rhz6.js"
     ],
     "css": [
       "assets/app-rSNWfdSN.css"

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,36 +1,36 @@
 {
-  "_ClientFormModal-CslBenG2.js": {
-    "file": "assets/ClientFormModal-CslBenG2.js",
+  "_ClientFormModal-D6yfxycS.js": {
+    "file": "assets/ClientFormModal-D6yfxycS.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js",
-      "_clients-5-rvP3_G.js"
+      "_clients-Dw0uhsgg.js"
     ]
   },
-  "_FactureFormModal-Ds50iCJK.js": {
-    "file": "assets/FactureFormModal-Ds50iCJK.js",
+  "_FactureFormModal-Cc2_yl8Y.js": {
+    "file": "assets/FactureFormModal-Cc2_yl8Y.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-Cnu0E0yz.js"
+      "_prestations-D3RLnEtE.js"
     ]
   },
-  "_TauxHoraireFormModal-CkS2Rhz6.js": {
-    "file": "assets/TauxHoraireFormModal-CkS2Rhz6.js",
+  "_TauxHoraireFormModal-cuYGX9hW.js": {
+    "file": "assets/TauxHoraireFormModal-cuYGX9hW.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_clients-5-rvP3_G.js": {
-    "file": "assets/clients-5-rvP3_G.js",
+  "_clients-Dw0uhsgg.js": {
+    "file": "assets/clients-Dw0uhsgg.js",
     "name": "clients",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-Cnu0E0yz.js": {
-    "file": "assets/prestations-Cnu0E0yz.js",
+  "_prestations-D3RLnEtE.js": {
+    "file": "assets/prestations-D3RLnEtE.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -43,7 +43,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-rSNWfdSN.css",
+    "file": "assets/app-BHmXZy-4.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -56,7 +56,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-BbqTxuXd.js",
+    "file": "assets/app-CCNbn-_v.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -74,54 +74,54 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-jWi3xnWq.js",
+    "file": "assets/Client-D9xWp8Xz.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_clients-5-rvP3_G.js",
-      "_ClientFormModal-CslBenG2.js"
+      "_clients-Dw0uhsgg.js",
+      "_ClientFormModal-D6yfxycS.js"
     ],
     "css": [
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-LTq4XsTF.js",
+    "file": "assets/Dashboard-COIafa13.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-Ds50iCJK.js",
-      "_prestations-Cnu0E0yz.js"
+      "_FactureFormModal-Cc2_yl8Y.js",
+      "_prestations-D3RLnEtE.js"
     ],
     "css": [
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-BNooromo.js",
+    "file": "assets/Facture-B2RANU2h.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-Ds50iCJK.js",
-      "_clients-5-rvP3_G.js",
-      "_prestations-Cnu0E0yz.js"
+      "_FactureFormModal-Cc2_yl8Y.js",
+      "_clients-Dw0uhsgg.js",
+      "_prestations-D3RLnEtE.js"
     ],
     "css": [
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-DuqdPO5D.js",
+    "file": "assets/Login-D3PaT9MZ.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -129,11 +129,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-Qo4QBkW8.js",
+    "file": "assets/NotFound-Cij_6wYX.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -141,27 +141,27 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-iqURn9_t.js",
+    "file": "assets/Prestation-DrOILUem.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-Cnu0E0yz.js",
-      "_clients-5-rvP3_G.js",
-      "_TauxHoraireFormModal-CkS2Rhz6.js",
-      "_ClientFormModal-CslBenG2.js"
+      "_prestations-D3RLnEtE.js",
+      "_clients-Dw0uhsgg.js",
+      "_TauxHoraireFormModal-cuYGX9hW.js",
+      "_ClientFormModal-D6yfxycS.js"
     ],
     "css": [
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-DKbBjRD-.js",
+    "file": "assets/Profile-BtMB38pH.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -170,11 +170,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-LkcvwGcU.js",
+    "file": "assets/PwaStatus-CT6gYqfE.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -183,23 +183,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-BG5ykEAL.js",
+    "file": "assets/TauxHoraire-DdKZJPD9.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-CkS2Rhz6.js"
+      "_TauxHoraireFormModal-cuYGX9hW.js"
     ],
     "css": [
-      "assets/app-rSNWfdSN.css"
+      "assets/app-BHmXZy-4.css"
     ]
   }
 }

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,36 +1,36 @@
 {
-  "_ClientFormModal-Cm-EfG_t.js": {
-    "file": "assets/ClientFormModal-Cm-EfG_t.js",
+  "_ClientFormModal-BsVzwJZl.js": {
+    "file": "assets/ClientFormModal-BsVzwJZl.js",
     "name": "ClientFormModal",
     "imports": [
       "resources/js/app.js",
-      "_clients-DpefF64T.js"
+      "_clients-DMKmMIbs.js"
     ]
   },
-  "_FactureFormModal-B2GyBTGq.js": {
-    "file": "assets/FactureFormModal-B2GyBTGq.js",
+  "_FactureFormModal-C8wEgc1N.js": {
+    "file": "assets/FactureFormModal-C8wEgc1N.js",
     "name": "FactureFormModal",
     "imports": [
       "resources/js/app.js",
-      "_prestations-DGNn47DW.js"
+      "_prestations-Dym4sfZg.js"
     ]
   },
-  "_TauxHoraireFormModal-Dou4ZpRI.js": {
-    "file": "assets/TauxHoraireFormModal-Dou4ZpRI.js",
+  "_TauxHoraireFormModal-C4oCDvWp.js": {
+    "file": "assets/TauxHoraireFormModal-C4oCDvWp.js",
     "name": "TauxHoraireFormModal",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_clients-DpefF64T.js": {
-    "file": "assets/clients-DpefF64T.js",
+  "_clients-DMKmMIbs.js": {
+    "file": "assets/clients-DMKmMIbs.js",
     "name": "clients",
     "imports": [
       "resources/js/app.js"
     ]
   },
-  "_prestations-DGNn47DW.js": {
-    "file": "assets/prestations-DGNn47DW.js",
+  "_prestations-Dym4sfZg.js": {
+    "file": "assets/prestations-Dym4sfZg.js",
     "name": "prestations",
     "imports": [
       "resources/js/app.js"
@@ -43,7 +43,7 @@
     "isDynamicEntry": true
   },
   "resources/css/app.css": {
-    "file": "assets/app-BGUOi8rf.css",
+    "file": "assets/app-rSNWfdSN.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -56,7 +56,7 @@
     "src": "resources/images/hills.jpg"
   },
   "resources/js/app.js": {
-    "file": "assets/app-Cs3DjPVY.js",
+    "file": "assets/app-BiD3PCeJ.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
@@ -74,54 +74,54 @@
     ],
     "css": [
       "assets/app-DySi9kHu.css",
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Client.vue": {
-    "file": "assets/Client-ZG_AYEza.js",
+    "file": "assets/Client-N4HQ2m-z.js",
     "name": "Client",
     "src": "resources/js/views/Client.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_clients-DpefF64T.js",
-      "_ClientFormModal-Cm-EfG_t.js"
+      "_clients-DMKmMIbs.js",
+      "_ClientFormModal-BsVzwJZl.js"
     ],
     "css": [
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Dashboard.vue": {
-    "file": "assets/Dashboard-DB9NDV7r.js",
+    "file": "assets/Dashboard-CuMWxa7J.js",
     "name": "Dashboard",
     "src": "resources/js/views/Dashboard.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-B2GyBTGq.js",
-      "_prestations-DGNn47DW.js"
+      "_FactureFormModal-C8wEgc1N.js",
+      "_prestations-Dym4sfZg.js"
     ],
     "css": [
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Facture.vue": {
-    "file": "assets/Facture-gfWM_FzG.js",
+    "file": "assets/Facture-B35D7ntP.js",
     "name": "Facture",
     "src": "resources/js/views/Facture.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_FactureFormModal-B2GyBTGq.js",
-      "_clients-DpefF64T.js",
-      "_prestations-DGNn47DW.js"
+      "_FactureFormModal-C8wEgc1N.js",
+      "_clients-DMKmMIbs.js",
+      "_prestations-Dym4sfZg.js"
     ],
     "css": [
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Login.vue": {
-    "file": "assets/Login-C-urmUKZ.js",
+    "file": "assets/Login-BWmqAIA1.js",
     "name": "Login",
     "src": "resources/js/views/Login.vue",
     "isDynamicEntry": true,
@@ -129,11 +129,11 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/NotFound.vue": {
-    "file": "assets/NotFound-ji_tXthn.js",
+    "file": "assets/NotFound-C35Uxrb6.js",
     "name": "NotFound",
     "src": "resources/js/views/NotFound.vue",
     "isDynamicEntry": true,
@@ -141,27 +141,27 @@
       "resources/js/app.js"
     ],
     "css": [
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Prestation.vue": {
-    "file": "assets/Prestation-q4Et_QXf.js",
+    "file": "assets/Prestation-DJwFlKGg.js",
     "name": "Prestation",
     "src": "resources/js/views/Prestation.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_prestations-DGNn47DW.js",
-      "_clients-DpefF64T.js",
-      "_TauxHoraireFormModal-Dou4ZpRI.js",
-      "_ClientFormModal-Cm-EfG_t.js"
+      "_prestations-Dym4sfZg.js",
+      "_clients-DMKmMIbs.js",
+      "_TauxHoraireFormModal-C4oCDvWp.js",
+      "_ClientFormModal-BsVzwJZl.js"
     ],
     "css": [
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/Profile.vue": {
-    "file": "assets/Profile-B1iRPKy7.js",
+    "file": "assets/Profile-Dv9jlFYA.js",
     "name": "Profile",
     "src": "resources/js/views/Profile.vue",
     "isDynamicEntry": true,
@@ -170,11 +170,11 @@
     ],
     "css": [
       "assets/Profile-DimUG-gv.css",
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   },
   "resources/js/views/PwaStatus.vue": {
-    "file": "assets/PwaStatus-C6sHO--g.js",
+    "file": "assets/PwaStatus-DKVEXbdS.js",
     "name": "PwaStatus",
     "src": "resources/js/views/PwaStatus.vue",
     "isDynamicEntry": true,
@@ -183,23 +183,23 @@
     ],
     "css": [
       "assets/PwaStatus-tn0RQdqM.css",
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ],
     "assets": [
       "assets/hills-CtrI9V8B.jpg"
     ]
   },
   "resources/js/views/TauxHoraire.vue": {
-    "file": "assets/TauxHoraire-Df2ZzpqW.js",
+    "file": "assets/TauxHoraire-BHxB0IeN.js",
     "name": "TauxHoraire",
     "src": "resources/js/views/TauxHoraire.vue",
     "isDynamicEntry": true,
     "imports": [
       "resources/js/app.js",
-      "_TauxHoraireFormModal-Dou4ZpRI.js"
+      "_TauxHoraireFormModal-C4oCDvWp.js"
     ],
     "css": [
-      "assets/app-BGUOi8rf.css"
+      "assets/app-rSNWfdSN.css"
     ]
   }
 }

--- a/resources/js/components/factures/FactureFormModal.vue
+++ b/resources/js/components/factures/FactureFormModal.vue
@@ -20,6 +20,17 @@
         <div v-for="n in 3" :key="n" class="h-16 bg-gray-800 rounded-xl animate-pulse"></div>
       </div>
 
+      <!-- Le chargement a échoué : surtout ne pas afficher « tout est facturé »,
+           qui serait un mensonge rassurant. -->
+      <div
+        v-else-if="errorsPrestations.fetch"
+        class="mt-8 p-6 text-center rounded-xl bg-red-500/10 border border-red-500/30"
+      >
+        <div class="text-3xl mb-2">⚠️</div>
+        <p class="text-red-400 font-semibold mb-1">Chargement impossible</p>
+        <p class="text-red-400/80 text-sm">{{ errorsPrestations.fetch }}</p>
+      </div>
+
       <!-- Aucune prestation à facturer, tous clients confondus -->
       <div
         v-else-if="unbilledPrestations.length === 0"
@@ -188,7 +199,11 @@ import { formatDate, formatNombre, formatEuros } from '@/utils';
 const emit = defineEmits(['close']);
 
 const prestationsStore = usePrestationsStore();
-const { unbilledPrestations, loading: loadingPrestations } = storeToRefs(prestationsStore);
+const {
+  unbilledPrestations,
+  loading: loadingPrestations,
+  errors: errorsPrestations,
+} = storeToRefs(prestationsStore);
 const { fetchPrestations } = prestationsStore;
 
 const invoicesStore = useInvoicesStore();
@@ -323,6 +338,12 @@ function basculerTout() {
 
 async function creerLaFacture() {
   if (!idsSelectionnes.value.length) return;
+
+  // Indispensable avant chaque tentative : apiCall ne vide que la clé de
+  // l'opération ('add'), jamais 'validationErrors'. Sans ce nettoyage, un 422
+  // suivi d'une erreur réseau laisserait le bandeau afficher l'ancien message
+  // (prioritaire) pendant que le toast en annonce un autre.
+  nettoyerErreurs();
 
   const succes = await addInvoice({ prestations: [...idsSelectionnes.value] });
 

--- a/resources/js/components/factures/FactureFormModal.vue
+++ b/resources/js/components/factures/FactureFormModal.vue
@@ -1,204 +1,324 @@
 <template>
   <div class="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-md z-50">
     <!-- Overlay cliquable pour fermer la modale -->
+    <div @click.self="close" class="absolute inset-0"></div>
 
-    <!-- Boîte de dialogue -->
-    <div class="bg-gray-900 p-8 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-auto border border-gray-800">
+    <div class="relative bg-gray-900 p-6 sm:p-8 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-auto border border-gray-800">
       <!-- En-tête -->
       <div class="flex justify-between items-center pb-4 border-b border-gray-800">
-        <h2 class="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-purple-400">
-          🧾 Nouvelle Facture
-        </h2>
-        <button 
-          @click="close" 
-          class="text-gray-400 hover:text-white transition-transform hover:scale-110"
-        >
-          ✕
-        </button>
+        <div>
+          <h2 class="text-2xl font-bold text-white">🧾 Nouvelle facture</h2>
+          <p v-if="clientChoisi" class="text-sm text-gray-400 mt-1">
+            {{ clientChoisi.nom }}
+          </p>
+        </div>
+        <button @click="close" class="text-gray-400 hover:text-white transition" aria-label="Fermer">✕</button>
       </div>
 
-      <!-- Liste des prestations -->
-      <div class="mt-6">
-        <h3 class="flex flex-col text-lg font-semibold text-white mb-4 flex items-center gap-4">
-          📋 Prestations disponibles
-          <span class="text-sm bg-gray-800 text-gray-400 px-3 py-1 rounded-full">
-            {{ unbilledPrestations.length }} non facturées
-          </span>
+      <!-- Chargement -->
+      <div v-if="loadingPrestations.fetch" class="mt-8 space-y-3">
+        <div v-for="n in 3" :key="n" class="h-16 bg-gray-800 rounded-xl animate-pulse"></div>
+      </div>
+
+      <!-- Aucune prestation à facturer, tous clients confondus -->
+      <div
+        v-else-if="unbilledPrestations.length === 0"
+        class="mt-8 p-8 text-center rounded-xl border-2 border-dashed border-gray-800"
+      >
+        <div class="text-4xl mb-3">🎉</div>
+        <p class="text-white font-semibold mb-1">Tout est facturé</p>
+        <p class="text-gray-400">Aucune prestation en attente de facturation.</p>
+      </div>
+
+      <!-- ÉTAPE 1 — choisir le client -->
+      <!-- Une facture ne peut concerner qu'un seul client : en le choisissant
+           d'abord, on rend l'erreur « clients différents » impossible. -->
+      <div v-else-if="!clientChoisi" class="mt-6">
+        <h3 class="text-sm uppercase tracking-wide text-gray-400 mb-3">
+          Pour quel client ?
         </h3>
 
-        <!-- <PrestationsFilters class="mb-4" /> -->
+        <div class="space-y-2">
+          <button
+            v-for="entree in clientsAFacturer"
+            :key="entree.client.id"
+            @click="choisirClient(entree.client)"
+            class="w-full flex items-center justify-between p-4 rounded-xl border border-gray-800 bg-gray-800/50 hover:border-indigo-500 hover:bg-indigo-500/10 transition text-left"
+          >
+            <span class="font-semibold text-white">{{ entree.client.nom }}</span>
+            <span class="text-sm text-gray-400 tabular-nums">
+              {{ entree.nombre }} prestation{{ entree.nombre > 1 ? 's' : '' }} ·
+              {{ formatNombre(entree.heures) }} h
+            </span>
+          </button>
+        </div>
+      </div>
 
-        <!-- État vide -->
-        <div 
-          v-if="unbilledPrestations.length === 0" 
-          class="p-6 text-center rounded-xl border-2 border-dashed border-gray-800 hover:border-indigo-500 transition-colors"
+      <!-- ÉTAPE 2 — choisir les prestations de ce client -->
+      <div v-else class="mt-6">
+        <button
+          @click="revenirAuxClients"
+          class="text-sm text-gray-400 hover:text-white transition mb-4"
         >
-          <div class="text-4xl mb-3">🎉</div>
-          <p class="text-gray-400">Aucune prestations à facturées !</p>
+          ← Changer de client
+        </button>
+
+        <!-- Filtre par mois : seulement s'il y a plusieurs mois à distinguer -->
+        <div v-if="moisDisponibles.length > 1" class="flex flex-wrap gap-2 mb-4">
+          <button
+            @click="moisFiltre = ''"
+            class="px-3 py-1 rounded-full text-sm border transition"
+            :class="moisFiltre === ''
+              ? 'bg-indigo-500 border-indigo-500 text-white'
+              : 'border-gray-700 text-gray-400 hover:border-gray-500'"
+          >
+            Tous les mois
+          </button>
+          <button
+            v-for="mois in moisDisponibles"
+            :key="mois"
+            @click="moisFiltre = mois"
+            class="px-3 py-1 rounded-full text-sm border transition"
+            :class="moisFiltre === mois
+              ? 'bg-indigo-500 border-indigo-500 text-white'
+              : 'border-gray-700 text-gray-400 hover:border-gray-500'"
+          >
+            {{ libelleMois(mois) }}
+          </button>
         </div>
 
-        <!-- Liste des prestations -->
-        <div v-else class="space-y-3">
-          <label class="flex items-center justify-center text-xl text-white mb-4">
-            <input type="checkbox" v-model="selectAll" @change="toggleAll" class="mr-2">
+        <!-- Tout sélectionner : ne porte que sur les prestations visibles -->
+        <label class="flex items-center gap-2 p-3 rounded-xl bg-gray-800/50 border border-gray-800 cursor-pointer mb-3">
+          <input
+            type="checkbox"
+            :checked="toutEstSelectionne"
+            :indeterminate.prop="selectionPartielle"
+            @change="basculerTout"
+            class="h-5 w-5 rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-2 focus:ring-indigo-500"
+          />
+          <span class="text-white font-medium">
             Tout sélectionner
-          </label>
+            <span class="text-gray-400 font-normal">({{ prestationsVisibles.length }})</span>
+          </span>
+        </label>
 
+        <div class="space-y-2">
           <label
-            v-for="prestation in unbilledPrestations"
+            v-for="prestation in prestationsVisibles"
             :key="prestation.id"
-            class="group flex items-center p-4 rounded-xl border border-gray-800 hover:border-indigo-500 bg-gray-800/50 cursor-pointer transition-all"
-            :class="{ 'border-indigo-500 bg-indigo-500/10': selectedPrestations.includes(prestation) }"
+            class="flex items-center gap-3 p-3 rounded-xl border bg-gray-800/50 cursor-pointer transition"
+            :class="idsSelectionnes.includes(prestation.id)
+              ? 'border-indigo-500 bg-indigo-500/10'
+              : 'border-gray-800 hover:border-gray-600'"
           >
+            <!-- On stocke l'identifiant, pas l'objet : une liste rafraîchie par
+                 le store recréerait les objets et viderait la sélection. -->
             <input
               type="checkbox"
-              v-model="selectedPrestations"
-              :value="prestation"
-              class="mt-1 h-5 w-5 rounded border-gray-700 bg-gray-800 checked:bg-indigo-500 checked:border-indigo-500 focus:ring-indigo-500/50"
+              v-model="idsSelectionnes"
+              :value="prestation.id"
+              class="h-5 w-5 rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-2 focus:ring-indigo-500"
             />
-            
-            <div class="ml-4 flex-1">
-                <div class="flex items-center justify-center gap-3">
-                  <span class="font-bold text-md bg-gray-900 text-gray-400 px-2 py-1 rounded-full">
-                    {{ formatDate(prestation.date) }}
-                  </span>
-                </div>
-                
-                <div class="grid grid-cols-2 gap-2 mt-2 font-bold">
-                  <div class="flex items-center justify-center gap-2 text-lg">
-                    <span class="text-gray-500">🕒</span>
-                    <span class="text-gray-300">{{ prestation.heures }}h</span>
-                  </div>
-                  <div class="flex items-center justify-center  gap-2 text-lg">
-                    <span class="text-gray-500">📍</span>
-                    <span class="text-gray-300 truncate">{{ prestation.adresse }}</span>
-                  </div>
-                  <div class="flex items-center justify-center  gap-2 text-lg">
-                    <span class="text-gray-500">👤</span>
-                    <span class="text-gray-300 truncate">{{ prestation.client.nom }}</span>
-                  </div>
-                  <div class="flex items-center justify-center  gap-2 text-lg">
-                    <span class="text-gray-500">💰</span>
-                    <span class="text-gray-300 truncate">{{ prestation.taux_horaire.taux }} € / h</span>
-                  </div>
-                </div>
+
+            <div class="flex-1 min-w-0 flex flex-wrap items-center gap-x-4 gap-y-1">
+              <span class="font-medium text-white tabular-nums">{{ formatDate(prestation.date) }}</span>
+              <span class="text-gray-400 tabular-nums">{{ formatNombre(prestation.heures) }} h</span>
+              <span class="text-gray-400 tabular-nums">{{ formatEuros(prestation.taux_horaire.taux) }} / h</span>
+              <span class="text-gray-500 truncate">{{ prestation.adresse }}</span>
             </div>
+
+            <span class="font-semibold text-white tabular-nums whitespace-nowrap">
+              {{ formatEuros(prestation.heures * prestation.taux_horaire.taux) }}
+            </span>
           </label>
         </div>
-      </div>
 
-      <!-- Récapitulatif -->
-      <div v-if="selectedPrestations.length !==0" class="mt-6 bg-gray-800 p-4 rounded-xl border border-gray-700">
-        <h3 class="text-lg font-semibold text-white mb-3 flex items-center gap-2">
-          📝 Récapitulatif
-        </h3>
-        
-        <div class="space-y-2">
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">Prestations sélectionnées :</span>
-            <span class="text-white font-medium">{{ selectedPrestations.length }}</span>
+        <!-- Récapitulatif -->
+        <div v-if="idsSelectionnes.length > 0" class="mt-5 p-4 rounded-xl bg-gray-800 border border-gray-700">
+          <div class="flex justify-between items-center text-sm mb-2">
+            <span class="text-gray-400">
+              {{ idsSelectionnes.length }} prestation{{ idsSelectionnes.length > 1 ? 's' : '' }} ·
+              {{ formatNombre(totalHeures) }} h
+            </span>
           </div>
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">Total heures :</span>
-            <span class="text-indigo-400 font-bold">{{ totalHeures }}h</span>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">Montant HT :</span>
-            <span class="text-green-400 font-bold">{{ totalHT }} €</span>
+            <span class="text-white font-semibold">Montant HT</span>
+            <span class="text-2xl font-bold text-white tabular-nums">{{ formatEuros(totalHT) }}</span>
           </div>
         </div>
-      </div>
 
-      <!-- Actions -->
-      <div v-if="selectedPrestations.length !==0" class="mt-6 flex flex-col sm:flex-row justify-end gap-3">
-        <button 
-          @click="close" 
-          class="px-6 py-3 rounded-xl font-semibold transition-all bg-gray-700 hover:bg-gray-600 text-white"
+        <!-- L'erreur s'affiche DANS la modale : la sélection n'est jamais perdue. -->
+        <div
+          v-if="errors.add"
+          class="mt-4 p-3 bg-red-500/10 text-red-400 rounded-lg border border-red-500/30"
         >
-          Annuler
-        </button>
-        <button
-          @click="createInvoiceHandler"
-          class="px-6 py-3 rounded-xl font-semibold transition-all bg-gradient-to-r from-indigo-500 to-purple-500 hover:from-indigo-600 hover:to-purple-600 text-white flex items-center justify-center"
-          :disabled="loading.add || selectedPrestations.length === 0"
-        >
-          <span v-if="loading.add" class="animate-spin mr-2">🌀</span>
-          <span v-else>✅</span>
-          Créer la Facture
-        </button>
-      </div>
+          ⚠️ {{ errors.add }}
+        </div>
 
-      <!-- Message d'erreur -->
-      <div 
-        v-if="errors.add" 
-        class="mt-4 p-3 bg-red-500/10 text-red-400 rounded-lg border border-red-500/30 flex items-center gap-2"
-      >
-        ⚠️ {{ errors.add }}
+        <!-- Actions -->
+        <div class="mt-6 flex flex-col sm:flex-row justify-end gap-3">
+          <button
+            @click="close"
+            class="px-6 py-3 rounded-xl font-semibold bg-gray-700 hover:bg-gray-600 text-white transition"
+          >
+            Annuler
+          </button>
+          <button
+            @click="creerLaFacture"
+            :disabled="loading.add || idsSelectionnes.length === 0"
+            class="px-6 py-3 rounded-xl font-semibold bg-indigo-500 hover:bg-indigo-400 text-white transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            <span v-if="loading.add" class="animate-spin border-2 border-white border-t-transparent rounded-full w-4 h-4"></span>
+            <span v-else>✅</span>
+            Créer la facture
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </template>
-  
-  <script setup>
-  import { ref, computed, onMounted } from "vue";
-  import { storeToRefs } from "pinia";
-  import { usePrestationsStore } from "@/stores/prestations";
-  import { useInvoicesStore } from "@/stores/factures";
-  import { PrestationsFilters } from "@/components/prestations/"
-  import { formatDate } from '@/utils'
-  
-  // Props et événements
-  const emit = defineEmits(["close"]);
-  const prestationsStore = usePrestationsStore();
-  const { unbilledPrestations } = storeToRefs(prestationsStore);
-  const { fetchPrestations } = prestationsStore;
 
-  const invoicesStore = useInvoicesStore();
-  const { addInvoice, loading, errors } = invoicesStore;
-  // Charger les prestations
-  onMounted(() => {
-    fetchPrestations();
-  });  
-  
-  // Sélection des prestations
-  const selectedPrestations = ref([]);
-  const selectAll = ref(false);
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
+import { usePrestationsStore } from '@/stores/prestations';
+import { useInvoicesStore } from '@/stores/factures';
+import { formatDate, formatNombre, formatEuros } from '@/utils';
 
-  const toggleAll = () => {
-    if (selectAll.value) {
-      selectedPrestations.value = [...unbilledPrestations.value];
-    } else {
-      selectedPrestations.value = [];
+const emit = defineEmits(['close']);
+
+const prestationsStore = usePrestationsStore();
+const { unbilledPrestations, loading: loadingPrestations } = storeToRefs(prestationsStore);
+const { fetchPrestations } = prestationsStore;
+
+const invoicesStore = useInvoicesStore();
+const { addInvoice, clearErrors } = invoicesStore;
+const { loading, errors } = storeToRefs(invoicesStore);
+
+onMounted(() => {
+  fetchPrestations();
+});
+
+const clientChoisi = ref(null);
+const idsSelectionnes = ref([]);
+const moisFiltre = ref('');
+
+/**
+ * Les clients ayant au moins une prestation à facturer, avec leur volume.
+ * C'est l'étape 1 : choisir le client rend impossible une facture à cheval
+ * sur plusieurs clients — ce que le serveur refuse.
+ */
+const clientsAFacturer = computed(() => {
+  const parClient = new Map();
+
+  for (const prestation of unbilledPrestations.value) {
+    const client = prestation.client;
+    if (!client) continue;
+
+    if (!parClient.has(client.id)) {
+      parClient.set(client.id, { client, nombre: 0, heures: 0 });
     }
-  };
-  
-  // Calcul du total des heures et du montant HT
-  const totalHeures = computed(() => {
-    return selectedPrestations.value
-      .reduce((sum, prestation) => sum + parseFloat(prestation.heures), 0);
-  });
-  
-  const totalHT = computed(() => {
-    return selectedPrestations.value.reduce((total, prestation) => {
-      return total + (prestation.taux_horaire.taux * prestation.heures)
-    }, 0);
-  });
-    
-  // Fonction de création de facture
-  async function createInvoiceHandler() {
-    if (!selectedPrestations.value.length) return;
-  
-    const payload = {
-      prestations: selectedPrestations.value.map((p) => p.id),
-    };
-  
-    await addInvoice(payload);
+
+    const entree = parClient.get(client.id);
+    entree.nombre += 1;
+    entree.heures += parseFloat(prestation.heures);
+  }
+
+  return [...parClient.values()].sort((a, b) => a.client.nom.localeCompare(b.client.nom));
+});
+
+// Les prestations du client choisi, les plus récentes d'abord.
+const prestationsDuClient = computed(() => {
+  if (!clientChoisi.value) return [];
+
+  return unbilledPrestations.value
+    .filter(p => p.client?.id === clientChoisi.value.id)
+    .sort((a, b) => b.date.localeCompare(a.date));
+});
+
+// `date` arrive au format Y-m-d : le mois est son préfixe.
+const moisDisponibles = computed(() => {
+  const mois = new Set(prestationsDuClient.value.map(p => p.date.slice(0, 7)));
+  return [...mois].sort().reverse();
+});
+
+const prestationsVisibles = computed(() => {
+  if (!moisFiltre.value) return prestationsDuClient.value;
+  return prestationsDuClient.value.filter(p => p.date.startsWith(moisFiltre.value));
+});
+
+const toutEstSelectionne = computed(() =>
+  prestationsVisibles.value.length > 0 &&
+  prestationsVisibles.value.every(p => idsSelectionnes.value.includes(p.id))
+);
+
+const selectionPartielle = computed(() =>
+  !toutEstSelectionne.value &&
+  prestationsVisibles.value.some(p => idsSelectionnes.value.includes(p.id))
+);
+
+const prestationsSelectionnees = computed(() =>
+  prestationsDuClient.value.filter(p => idsSelectionnes.value.includes(p.id))
+);
+
+const totalHeures = computed(() =>
+  prestationsSelectionnees.value.reduce((somme, p) => somme + parseFloat(p.heures), 0)
+);
+
+const totalHT = computed(() =>
+  prestationsSelectionnees.value.reduce(
+    (somme, p) => somme + parseFloat(p.heures) * parseFloat(p.taux_horaire.taux),
+    0
+  )
+);
+
+function libelleMois(mois) {
+  const [annee, m] = mois.split('-');
+  const nom = new Intl.DateTimeFormat('fr-FR', { month: 'long' })
+    .format(new Date(Number(annee), Number(m) - 1, 1));
+  return `${nom} ${annee}`;
+}
+
+function choisirClient(client) {
+  clientChoisi.value = client;
+  idsSelectionnes.value = [];
+  moisFiltre.value = '';
+  clearErrors('add');
+}
+
+function revenirAuxClients() {
+  clientChoisi.value = null;
+  idsSelectionnes.value = [];
+  moisFiltre.value = '';
+  clearErrors('add');
+}
+
+// Ne bascule que les prestations visibles : un filtre de mois actif ne doit pas
+// embarquer silencieusement les prestations des autres mois.
+function basculerTout() {
+  const idsVisibles = prestationsVisibles.value.map(p => p.id);
+
+  if (toutEstSelectionne.value) {
+    idsSelectionnes.value = idsSelectionnes.value.filter(id => !idsVisibles.includes(id));
+  } else {
+    idsSelectionnes.value = [...new Set([...idsSelectionnes.value, ...idsVisibles])];
+  }
+}
+
+async function creerLaFacture() {
+  if (!idsSelectionnes.value.length) return;
+
+  const succes = await addInvoice({ prestations: [...idsSelectionnes.value] });
+
+  // On ne ferme QUE si la création a réussi : sinon la sélection serait perdue
+  // et le message d'erreur ne serait jamais lu.
+  if (succes) {
     close();
   }
-  
-  // Fonction pour fermer la modale
-  const close = () => {
-    emit("close");
-  };
-  </script>
-  
+}
+
+const close = () => {
+  clearErrors('add');
+  emit('close');
+};
+</script>

--- a/resources/js/components/factures/FactureFormModal.vue
+++ b/resources/js/components/factures/FactureFormModal.vue
@@ -149,10 +149,10 @@
 
         <!-- L'erreur s'affiche DANS la modale : la sélection n'est jamais perdue. -->
         <div
-          v-if="errors.add"
+          v-if="messageErreur"
           class="mt-4 p-3 bg-red-500/10 text-red-400 rounded-lg border border-red-500/30"
         >
-          ⚠️ {{ errors.add }}
+          ⚠️ {{ messageErreur }}
         </div>
 
         <!-- Actions -->
@@ -272,6 +272,22 @@ const totalHT = computed(() =>
   )
 );
 
+/**
+ * L'erreur vient de deux endroits selon le code HTTP, et c'est un piège :
+ * apiCall range un 422 dans `errors.validationErrors` (SANS déclencher de toast),
+ * et tout le reste dans `errors.add` (avec toast). Or 422 est justement le cas
+ * nominal ici — prestation déjà facturée, clients différents. N'afficher que
+ * `errors.add` laisserait l'utilisateur devant un bouton qui ne fait « rien ».
+ */
+const messageErreur = computed(() =>
+  errors.value.validationErrors?.prestations?.[0] ?? errors.value.add ?? null
+);
+
+function nettoyerErreurs() {
+  clearErrors('add');
+  clearErrors('validationErrors');
+}
+
 function libelleMois(mois) {
   const [annee, m] = mois.split('-');
   const nom = new Intl.DateTimeFormat('fr-FR', { month: 'long' })
@@ -283,14 +299,14 @@ function choisirClient(client) {
   clientChoisi.value = client;
   idsSelectionnes.value = [];
   moisFiltre.value = '';
-  clearErrors('add');
+  nettoyerErreurs();
 }
 
 function revenirAuxClients() {
   clientChoisi.value = null;
   idsSelectionnes.value = [];
   moisFiltre.value = '';
-  clearErrors('add');
+  nettoyerErreurs();
 }
 
 // Ne bascule que les prestations visibles : un filtre de mois actif ne doit pas
@@ -318,7 +334,7 @@ async function creerLaFacture() {
 }
 
 const close = () => {
-  clearErrors('add');
+  nettoyerErreurs();
   emit('close');
 };
 </script>

--- a/resources/js/stores/auth.js
+++ b/resources/js/stores/auth.js
@@ -29,7 +29,6 @@ export const useAuthStore = defineStore("auth", () => {
 
   /** Connexion utilisateur */
   async function login(email, password) {
-    console.log('LOGIN VALUE', loading.value);
     loading.value['login'] = true;
     errors.value['login'] = null;
     try {

--- a/resources/js/stores/factures.js
+++ b/resources/js/stores/factures.js
@@ -98,12 +98,17 @@ export const useInvoicesStore = defineStore('invoices', () => {
       request: () => axios.post('/api/factures', invoice),
       onSuccess: (response) => {
         invoices.value.push(response.data.facture);
-        
+
         if(dashboardStore.dashboardData) {
           dashboardStore.fetchDashboard();
         }
 
         notify('success', response.data.message);
+
+        // Signale explicitement le succès : apiCall renvoie ce que retourne
+        // onSuccess. Sans ce `true`, l'appelant reçoit `undefined` et ne peut
+        // pas distinguer une création réussie d'un échec.
+        return true;
       },
     });
   }

--- a/resources/js/stores/prestations.js
+++ b/resources/js/stores/prestations.js
@@ -51,13 +51,7 @@ export const usePrestationsStore = defineStore('prestations', () => {
   });
 
   const unbilledPrestations = computed(() => {
-    return prestations.value.filter((prestation) => { 
-      
-      console.log('PRESTATION', prestation)
-      console.log(prestation.facture_id)
-      return prestation.facture_id == null
-
-    });
+    return prestations.value.filter((prestation) => prestation.facture_id == null);
   });
 
   function clearErrors(operation) {


### PR DESCRIPTION
Une facture ne peut concerner **qu'un seul client** — le backend le refuse en 422. Mais le formulaire listait **toutes** les prestations non facturées, tous clients confondus, avec un « tout sélectionner » qui les cochait toutes. Dès que deux clients ont des prestations en attente, ce bouton produisait mécaniquement une erreur : **l'interface invitait à faire ce que le serveur interdit**.

## Le nouveau flux

**Étape 1** — la liste des clients ayant des prestations en attente, chacun avec son volume (« EBS — 25 prestations · 238,00 h »).
**Étape 2** — seules **ses** prestations s'affichent, les plus récentes d'abord, avec un « tout sélectionner » et un filtre par mois (affiché uniquement s'il y a plusieurs mois à distinguer).

L'erreur « clients différents » devient **impossible par construction**, au lieu d'être rattrapée par un message. Facturer les 25 prestations de juin prend trois clics.

## Les défauts corrigés au passage

**La modale se fermait même en cas d'échec** (`await addInvoice(payload); close();`), perdant la sélection — et rendant son propre bloc d'erreur inaffichable. Elle ne se ferme plus qu'en cas de succès. Il a fallu pour cela faire retourner `true` à `addInvoice`, qui ne retournait **rien** : `apiCall` renvoie ce que retourne `onSuccess`, et celui-ci n'avait pas de `return`.

**L'erreur de validation n'était jamais affichable.** `apiCall` range un 422 dans `errors.validationErrors` — *sans* déclencher de toast — et tout le reste dans `errors.add`. Or 422 est justement le cas nominal ici. La modale lit désormais les deux sources ; sans quoi l'utilisateur cliquait « Créer la facture » et ne voyait **rien du tout**.

**La sélection stockait les objets**, pas leurs identifiants : elle dépendait de l'identité des références JavaScript, donc un rafraîchissement de la liste par le store la vidait silencieusement.

**Des `console.log` tournaient en production** — deux par prestation à chaque recalcul dans le store, et un dans `auth.js` qui journalisait l'état de connexion.

Et : overlay cliquable (le commentaire l'annonçait sans que ce soit vrai), totaux arrondis (`5950.000000000001` était possible), « tout sélectionner » enfin synchronisé avec les cases individuelles, orthographe.

## Trouvé en revue, corrigé

`apiCall` ne vide que la clé de l'opération, jamais `validationErrors`. Un 422 suivi d'une erreur réseau laissait donc le bandeau afficher l'ancien message pendant que le toast en annonçait un autre — deux informations contradictoires. On nettoie maintenant avant chaque tentative.

Et si le chargement des prestations échouait, la modale affichait « 🎉 Tout est facturé » : un mensonge rassurant. Elle affiche désormais l'erreur.

## Vérifications

- `npm run build` passe.
- Backend inchangé : 90 tests verts.
- Revue : retour de `true`/`undefined` d'`addInvoice`, portée du « tout sélectionner » (les prestations d'un mois restent sélectionnées quand on change de filtre), calculs monétaires (les heures arrivent en chaînes), réactivité Pinia — tout vérifié.

## Note

Les deux stores n'ont pas le même `apiCall` : celui des clients fait `return response`, celui des factures `return onSuccess(response)`. Je ne les ai pas alignés, car `getInvoicePdf` dépend du second comportement pour renvoyer l'URL de son blob. Incohérence à garder en tête.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj