### PR TITLE
Tests front : caractériser les stores avant de refactorer apiCall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,23 @@ jobs:
 
       - name: Exécution des tests
         run: php artisan test
+
+  tests-front:
+    name: Tests (front)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout du code
+        uses: actions/checkout@v4
+
+      - name: Installation de Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Installation des dépendances npm
+        run: npm ci
+
+      - name: Exécution des tests front
+        run: npm run test

--- a/docs/superpowers/plans/2026-07-13-tests-front-stores.md
+++ b/docs/superpowers/plans/2026-07-13-tests-front-stores.md
@@ -1,0 +1,421 @@
+# Tests front des stores — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Installer Vitest et caractériser le comportement actuel des stores Pinia, pour disposer d'un filet avant d'extraire `apiCall` (dupliqué dans cinq stores, dont un a divergé).
+
+**Architecture :** Des tests de *caractérisation* — ils décrivent ce que le code **fait**, pas ce qu'il devrait faire. Ils doivent passer sur le code d'aujourd'hui **sans qu'une seule ligne des stores soit modifiée**. Au moment du refactor, ce qui reste vert n'a pas bougé ; ce qui casse est exactement ce qu'on a changé.
+
+**Tech Stack :** Vitest 4 (environnement `node`, pas de DOM), Pinia, Vue 3, Vite 7.
+
+## Global Constraints
+
+- Spec de référence : `docs/superpowers/specs/2026-07-13-tests-front-stores-design.md`
+- **INTERDIT de modifier `resources/js/stores/*.js`.** C'est le critère de réussite du plan. Si un test ne passe pas, c'est le TEST qui est faux, pas le store. `git status` ne doit montrer, à la fin, que des fichiers de test, la config, `package.json`, `package-lock.json` et le workflow.
+- **Les tests décrivent le comportement EXISTANT, y compris ses défauts et ses divergences.** Ne « corrige » rien en passant. Le store des factures retourne le résultat de `onSuccess` là où les autres retournent la réponse : le test doit **constater** cela, pas le déplorer.
+- **Pas de `jsdom` ni de `happy-dom`.** On ne teste que des stores : aucun rendu, donc `environment: 'node'`. N'installe rien d'autre que `vitest`.
+- **Piège 1 :** `resources/js/utils.js` appelle `useToast()` **au chargement du module** (pas dans une fonction). Importer un store — qui importe `utils` — déclencherait cet appel hors application Vue. Il FAUT mocker `@/utils` dans chaque fichier de test.
+- **Piège 2 :** `resources/js/stores/factures.js` importe le store du dashboard. Chaque test doit activer une instance Pinia (`setActivePinia(createPinia())`) avant d'instancier un store.
+- **Piège 3 :** l'alias `@ → resources/js` n'est PAS dans `vite.config.js` — c'est `laravel-vite-plugin` qui l'injecte. Vitest ne le verrait pas : il doit être redéclaré dans `vitest.config.js`.
+- Vitest 4 supporte Vite 7 (vérifié : peer dependency `vite: '^6.0.0 || ^7.0.0 || ^8.0.0'`).
+- Le backend n'est pas touché : la suite PHP (90 tests) doit rester verte.
+- Commits en français, format `type: description`.
+
+**Noms exacts des stores** (à ne pas deviner) :
+
+| Fichier | Export |
+|---|---|
+| `@/stores/clients` | `useClientsStore` |
+| `@/stores/taux-horaires` | `useTauxHorairesStore` |
+| `@/stores/prestations` | `usePrestationsStore` |
+| `@/stores/factures` | `useInvoicesStore` (en anglais — c'est ainsi, ne le renomme pas) |
+| `@/stores/auth` | `useAuthStore` |
+
+**Sur la forme du plan :** la tâche 1 donne le fichier de test **en entier** — c'est la référence. Les tâches 2 et 3 ne répètent que les tests *spécifiques* (les divergences, la logique métier), car les quatre autres fichiers déclinent le même squelette (mêmes mocks, même `beforeEach`, même helper `erreurAxios`) sur des noms de fonctions différents. Recopier quatre fois quatre-vingts lignes quasi identiques rendrait ce plan illisible sans rien apporter. Lis `clients.test.js` et les stores concernés : tout ce qu'il te faut y est.
+
+---
+
+### Task 1 : L'outillage, et le premier store caractérisé
+
+On installe Vitest et on caractérise `clients` — le store « standard », dont l'`apiCall` est partagé à l'identique par `taux-horaires` et `prestations`. S'il passe, l'outillage est bon.
+
+**Files:**
+- Modify: `package.json`
+- Create: `vitest.config.js`
+- Create: `resources/js/stores/clients.test.js`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: `npm run test` lance Vitest. Le pattern de mock (`axios` + `@/utils`) et l'amorce Pinia que les tâches 2 et 3 réutilisent.
+
+- [ ] **Step 1: Installer Vitest**
+
+Run: `npm install -D vitest`
+Expected: installation réussie, `vitest` apparaît dans les `devDependencies` de `package.json`.
+
+- [ ] **Step 2: Ajouter les scripts npm**
+
+Dans `package.json`, ajouter aux `scripts` :
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+- [ ] **Step 3: Créer la configuration de test**
+
+Créer `vitest.config.js` :
+
+```js
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Config dédiée, distincte de vite.config.js : celui-ci charge trois plugins
+// (Laravel, PWA, Tailwind) inutiles ici et sources de fragilité.
+export default defineConfig({
+  test: {
+    // Aucun rendu de composant : les stores n'ont pas besoin d'un DOM.
+    environment: 'node',
+    include: ['resources/js/**/*.test.js'],
+  },
+  resolve: {
+    alias: {
+      // Dans l'application, cet alias est injecté par laravel-vite-plugin,
+      // et non déclaré dans vite.config.js. Vitest ne le verrait donc pas.
+      '@': fileURLToPath(new URL('./resources/js', import.meta.url)),
+    },
+  },
+});
+```
+
+- [ ] **Step 4: Écrire les tests du store clients**
+
+Créer `resources/js/stores/clients.test.js` :
+
+```js
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import axios from 'axios';
+import { useClientsStore } from '@/stores/clients';
+import { notify } from '@/utils';
+
+vi.mock('axios');
+
+// utils.js appelle useToast() AU CHARGEMENT DU MODULE : sans ce mock, importer
+// un store planterait hors application Vue.
+vi.mock('@/utils', () => ({
+  notify: vi.fn(),
+  formatDate: vi.fn(),
+  formatNombre: vi.fn(),
+  formatEuros: vi.fn(),
+  validateEmail: vi.fn(),
+}));
+
+/** Construit une erreur axios telle que le store la reçoit. */
+function erreurAxios(status, data = {}) {
+  return { response: { status, data } };
+}
+
+describe('store clients — apiCall (le comportement de référence)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('retourne la reponse au succes', async () => {
+    axios.get.mockResolvedValue({ data: { clients: [{ id: 1, nom: 'EBS' }] } });
+    const store = useClientsStore();
+
+    const resultat = await store.fetchClients();
+
+    // Le comportement de référence : apiCall retourne la RÉPONSE.
+    expect(resultat).toBeTruthy();
+    expect(resultat.data.clients).toHaveLength(1);
+    expect(store.clients).toHaveLength(1);
+  });
+
+  it('redescend le chargement a false apres un succes', async () => {
+    axios.get.mockResolvedValue({ data: { clients: [] } });
+    const store = useClientsStore();
+
+    await store.fetchClients();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('redescend le chargement a false meme apres un echec', async () => {
+    axios.get.mockRejectedValue(erreurAxios(500, { message: 'Boom' }));
+    const store = useClientsStore();
+
+    await store.fetchClients();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('range un 422 dans validationErrors, SANS notifier', async () => {
+    axios.post.mockRejectedValue(
+      erreurAxios(422, { errors: { nom: ['Le nom est obligatoire.'] } })
+    );
+    const store = useClientsStore();
+
+    const resultat = await store.addClient({ nom: '' });
+
+    expect(store.errors.validationErrors).toEqual({ nom: ['Le nom est obligatoire.'] });
+    // Un 422 ne déclenche AUCUN toast : c'est ce qui a rendu un bloc d'erreur
+    // inaffichable dans la modale de facture.
+    expect(notify).not.toHaveBeenCalled();
+    expect(resultat).toBeFalsy();
+  });
+
+  it('range les autres erreurs dans errors[operation] ET notifie', async () => {
+    axios.post.mockRejectedValue(erreurAxios(500, { message: 'Erreur serveur' }));
+    const store = useClientsStore();
+
+    const resultat = await store.addClient({ nom: 'EBS' });
+
+    expect(store.errors.add).toBe('Erreur serveur');
+    expect(notify).toHaveBeenCalledWith('error', 'Erreur serveur');
+    expect(resultat).toBeFalsy();
+  });
+
+  it('vide l\'erreur precedente de l\'operation avant un nouvel appel', async () => {
+    const store = useClientsStore();
+
+    axios.post.mockRejectedValueOnce(erreurAxios(500, { message: 'Erreur serveur' }));
+    await store.addClient({ nom: 'EBS' });
+    expect(store.errors.add).toBe('Erreur serveur');
+
+    axios.post.mockResolvedValueOnce({ data: { client: { id: 1 }, message: 'Créé' } });
+    await store.addClient({ nom: 'EBS' });
+
+    expect(store.errors.add).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 5: Lancer les tests**
+
+Run: `npm run test`
+Expected: PASS — 6 tests.
+
+Si un test échoue, **ne touche PAS au store** : c'est ton test qui décrit mal le comportement réel. Lis `resources/js/stores/clients.js` et corrige le test.
+
+- [ ] **Step 6: Vérifier qu'aucun store n'a été modifié**
+
+Run: `git status --short resources/js/stores/`
+Expected: seul `clients.test.js` (nouveau fichier) apparaît. **Aucun `.js` de store modifié.** C'est le critère de réussite du plan.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json package-lock.json vitest.config.js resources/js/stores/clients.test.js
+git commit -m "test: installe vitest et caracterise le store clients"
+```
+
+---
+
+### Task 2 : Les quatre autres stores, divergences comprises
+
+**Files:**
+- Create: `resources/js/stores/taux-horaires.test.js`
+- Create: `resources/js/stores/prestations.test.js`
+- Create: `resources/js/stores/factures.test.js`
+- Create: `resources/js/stores/auth.test.js`
+
+**Interfaces:**
+- Consumes: la config et le pattern de mock de la tâche 1.
+- Produces: rien (la tâche 3 est indépendante).
+
+Le cœur de cette tâche : **figer les deux divergences**.
+
+- `auth` **relance l'erreur** (`throw err` dans son `catch`). Les quatre autres ne relancent pas.
+- `factures` retourne **le résultat de `onSuccess`**, là où les autres retournent la réponse. C'est la divergence qui a produit le bug d'`addInvoice` (qui ne retournait rien, donc la modale se fermait même en cas d'échec). Le test doit la **constater** telle quelle : il devra être modifié lors du refactor, et c'est précisément ce qui documentera le changement.
+
+- [ ] **Step 1: Caractériser taux-horaires et prestations (l'apiCall standard)**
+
+Ces deux stores ont un `apiCall` **identique caractère pour caractère** à celui de `clients`. Lis-les pour connaître les noms exacts de leurs fonctions et les clés de leurs réponses (`resources/js/stores/taux-horaires.js`, `resources/js/stores/prestations.js`).
+
+Créer `resources/js/stores/taux-horaires.test.js` et `resources/js/stores/prestations.test.js`, sur le modèle exact de `clients.test.js` (même en-tête de mocks, même `beforeEach`, même helper `erreurAxios`). Pour chacun, couvrir :
+
+- le succès retourne la **réponse** ;
+- `loading[operation]` redescend à `false` au succès **et** à l'échec ;
+- un 422 va dans `errors.validationErrors`, **sans** `notify` ;
+- une erreur 500 va dans `errors[operation]` **avec** `notify`.
+
+- [ ] **Step 2: Caractériser le store des factures (LA divergence)**
+
+Créer `resources/js/stores/factures.test.js`. Lis d'abord `resources/js/stores/factures.js` pour les noms exacts.
+
+Points à couvrir, en plus du 422 / 500 / loading :
+
+```js
+it('DIVERGENCE : apiCall retourne le resultat de onSuccess, pas la reponse', async () => {
+  // Les quatre autres stores font `if (onSuccess) onSuccess(response); return response;`
+  // Celui-ci fait `return onSuccess ? onSuccess(response) : response;`
+  // addInvoice retourne donc ce que retourne SON onSuccess — un `true` explicite,
+  // ajouté précisément parce que sans lui l'appelant recevait `undefined` et ne
+  // pouvait pas distinguer un succès d'un échec.
+  axios.post.mockResolvedValue({ data: { facture: { id: 1 }, message: 'Créée' } });
+  const store = useInvoicesStore();
+
+  const resultat = await store.addInvoice({ prestations: [1] });
+
+  expect(resultat).toBe(true);   // et NON la réponse axios
+});
+
+it('addInvoice retourne une valeur falsy en cas d\'echec', async () => {
+  axios.post.mockRejectedValue({ response: { status: 422, data: { errors: { prestations: ['Déjà facturée.'] } } } });
+  const store = useInvoicesStore();
+
+  const resultat = await store.addInvoice({ prestations: [1] });
+
+  // C'est ce qui permet à la modale de ne PAS se fermer sur un échec.
+  expect(resultat).toBeFalsy();
+  expect(store.errors.validationErrors).toEqual({ prestations: ['Déjà facturée.'] });
+});
+
+it('paid indexe la cle de chargement par facture', async () => {
+  // Une clé unique ("paid") ferait clignoter le bouton de TOUTES les lignes.
+  axios.patch.mockResolvedValue({ data: { facture: { id: 12, statut: 'payé' }, message: 'Payée' } });
+  const store = useInvoicesStore();
+
+  await store.paid(12);
+
+  expect(store.loading.paid_12).toBe(false);   // la clé existe, indexée
+  expect(store.loading.paid).toBeUndefined();  // et surtout : PAS de clé globale
+});
+```
+
+> Note : `factures.js` importe le store du dashboard. L'amorce `setActivePinia(createPinia())` du `beforeEach` suffit — ne mocke pas le store du dashboard, laisse-le s'instancier.
+
+- [ ] **Step 3: Caractériser le store auth (il RELANCE l'erreur)**
+
+Créer `resources/js/stores/auth.test.js`. Lis d'abord `resources/js/stores/auth.js`.
+
+La spécificité à figer :
+
+```js
+it('DIVERGENCE : auth relance l\'erreur apres l\'avoir traitee', async () => {
+  // Son catch se termine par `throw err;` — les quatre autres stores ne relancent pas.
+  // Ses appelants peuvent donc l'attraper. Retirer ce throw les casserait en silence.
+  axios.get.mockResolvedValue({});   // /sanctum/csrf-cookie
+  axios.post.mockRejectedValue({ response: { status: 401, data: { message: 'Identifiants invalides' } } });
+  const store = useAuthStore();
+
+  await expect(store.login('a@b.c', 'mauvais')).rejects.toBeDefined();
+
+  expect(store.errors.login).toBe('Identifiants invalides');
+});
+```
+
+> `login` appelle `axios.get('/sanctum/csrf-cookie')` avant le `POST` : il faut donc mocker les deux.
+
+- [ ] **Step 4: Lancer toute la suite**
+
+Run: `npm run test`
+Expected: PASS — tous les fichiers de test.
+
+Rappel : si un test échoue, **le store a raison, pas le test**. Ne modifie aucun store.
+
+- [ ] **Step 5: Vérifier qu'aucun store n'a été modifié**
+
+Run: `git status --short resources/js/stores/`
+Expected: uniquement des fichiers `.test.js` (nouveaux). Aucun `.js` de store modifié.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resources/js/stores/*.test.js
+git commit -m "test: caracterise les stores taux-horaires, prestations, factures et auth"
+```
+
+---
+
+### Task 3 : La logique métier, et le job CI
+
+**Files:**
+- Create: `resources/js/stores/logique-metier.test.js`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: la config de la tâche 1.
+- Produces: rien (dernière tâche).
+
+On couvre la logique qu'on a déjà vue se tromper : filtres, tri, sélection.
+
+- [ ] **Step 1: Caractériser la logique métier des stores**
+
+Créer `resources/js/stores/logique-metier.test.js`. Lis `resources/js/stores/prestations.js` et `resources/js/stores/factures.js` pour les noms exacts.
+
+À couvrir :
+
+**Store des prestations :**
+- `unbilledPrestations` ne retient que les prestations dont `facture_id` est `null`.
+- `filteredPrestations` : filtres `month_year`, `client_id`, `taux_horaire_id`.
+- `isAnyFilterActive` : `false` quand tous les filtres sont des chaînes vides, `true` dès qu'un seul est renseigné.
+
+**Store des factures :**
+- `filteredInvoices` est triée par **`id` décroissant** — jamais par `created_at`, que l'API renvoie au format `d/m/Y H:i:s`, intriable en JavaScript. Écris un test qui le prouve : injecte des factures dont l'ordre par `id` contredit l'ordre du tableau source.
+- Le filtre par **statut**.
+- Le filtre par **client** (il compare `invoice.prestations[0].client_id`).
+- Le filtre par **mois** : une facture est retenue si **au moins une** de ses prestations tombe dans le mois (`prestation.date` est au format `Y-m-d`, la comparaison est un préfixe).
+- Une facture **sans prestation** ne fait pas planter les filtres (l'accès est protégé par `?.`).
+
+Pour alimenter ces stores sans passer par l'API, injecte directement dans leur état : `store.prestations = [...]` / `store.invoices = [...]`. Les `watch` qui recalculent les listes filtrées sont **asynchrones** : après avoir modifié l'état, `await nextTick()` (importé de `vue`) avant d'asserter, sinon tu lis la valeur d'avant.
+
+- [ ] **Step 2: Lancer la suite**
+
+Run: `npm run test`
+Expected: PASS — tous les tests.
+
+- [ ] **Step 3: Ajouter le job CI**
+
+Dans `.github/workflows/ci.yml`, ajouter un **second job**, à côté du job `tests` existant (ne le modifie pas) :
+
+```yaml
+  tests-front:
+    name: Tests (front)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout du code
+        uses: actions/checkout@v4
+
+      - name: Installation de Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Installation des dépendances npm
+        run: npm ci
+
+      - name: Exécution des tests front
+        run: npm run test
+```
+
+- [ ] **Step 4: Valider la syntaxe YAML**
+
+Run: `npx --yes js-yaml .github/workflows/ci.yml > /dev/null && echo "YAML valide"`
+Expected: `YAML valide`. Une erreur d'indentation dans un workflow ne se voit qu'une fois poussé.
+
+- [ ] **Step 5: Vérifier que le backend n'a pas bougé**
+
+Run: `php artisan test`
+Expected: PASS — 90 tests (1 ignoré). Rien de ce plan ne touche au backend ; un échec ici signalerait une erreur.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resources/js/stores/logique-metier.test.js .github/workflows/ci.yml
+git commit -m "test: caracterise la logique metier des stores et ajoute le job CI front"
+```
+
+---
+
+## Vérification finale
+
+- [ ] `npm run test` — tous les tests passent.
+- [ ] **`git diff main --stat -- resources/js/stores/*.js`** — **AUCUN store modifié**. C'est le critère de réussite du plan : les tests décrivent le code tel qu'il est. S'il a fallu toucher un store, le filet ne vaut rien.
+- [ ] `php artisan test` — 90 tests verts (backend intact).
+- [ ] Sur la PR : la CI affiche **deux jobs verts et distincts** — « Tests (Pest) » et « Tests (front) ».

--- a/docs/superpowers/specs/2026-07-13-tests-front-stores-design.md
+++ b/docs/superpowers/specs/2026-07-13-tests-front-stores-design.md
@@ -1,0 +1,141 @@
+# Tests front : caractériser les stores avant de les refactorer
+
+Date : 2026-07-13
+
+## Problème
+
+Le projet n'a **aucun test front**. Toute la logique des stores Pinia — appels API,
+gestion du chargement, des erreurs, des notifications, filtres, tris, totaux — n'est
+vérifiée que par la lecture et par un parcours manuel dans l'application.
+
+Ce trou a un coût mesurable. Rien que dans les dernières PR, il a laissé passer :
+
+- `addInvoice` qui ne retournait **rien** (son `onSuccess` n'avait pas de `return`,
+  et `apiCall` renvoie ce que retourne `onSuccess`) : la modale de création se
+  fermait donc même en cas d'échec, effaçant la sélection de l'utilisateur ;
+- un bloc d'erreur qui **ne pouvait jamais s'afficher**, parce qu'`apiCall` range
+  les 422 dans `errors.validationErrors` — sans toast — alors que le composant ne
+  lisait que `errors.add` ;
+- `loading.paid`, une clé unique partagée par toutes les factures, qui faisait
+  clignoter le bouton de toutes les lignes en attente.
+
+Aucun de ces défauts n'était visible au build. Tous auraient été attrapés par un
+test de store.
+
+**Le déclencheur immédiat** : on veut extraire `apiCall`, dupliqué dans cinq
+stores, dont un a divergé. Refactorer cinq stores sans filet, en se reposant sur
+un parcours manuel, reproduirait exactement la méthode qui a produit ces bugs.
+
+## Décisions
+
+**Écrire les tests AVANT le refactor, sur le code actuel, sans le modifier.**
+Ce sont des tests de *caractérisation* : ils décrivent ce que le code **fait**, pas
+ce qu'il **devrait** faire. Ils captureront donc aussi les divergences — le test du
+store des factures constatera qu'il retourne le résultat de `onSuccess`, celui des
+clients qu'il retourne la réponse.
+
+C'est contre-intuitif mais c'est le cœur de la démarche : un test qui décrit le
+comportement *souhaité* ne prouve rien tant que le refactor n'est pas fait. Un test
+qui décrit le comportement *existant* devient un juge dès qu'on touche au code —
+ce qui reste vert n'a pas bougé, ce qui casse est exactement ce qu'on a changé.
+
+**Critère de réussite, vérifiable :** ces tests passent sur le code d'aujourd'hui
+**sans qu'une seule ligne des stores soit modifiée**. Si un store doit être touché
+pour faire passer un test, c'est le test qui est faux.
+
+**Périmètre : les stores seulement.** Pas de `@vue/test-utils`, pas de test de
+composant. C'est le filet dont le refactor a besoin, et cela couvre la logique la
+plus fragile. Les composants viendront séparément, si le besoin s'en fait sentir.
+
+**Un job CI distinct** (« Tests (front) »), séparé du job PHP : quand la CI échoue,
+on voit immédiatement de quel côté.
+
+## Conception
+
+### L'outillage
+
+`vitest` seul, en `devDependency`. **Pas de `jsdom` ni de `happy-dom`** : on ne teste
+que des stores, il n'y a aucun rendu, donc l'environnement `node` suffit. Vitest 4
+supporte Vite 7 (vérifié : `vite: '^6.0.0 || ^7.0.0 || ^8.0.0'` dans ses peer
+dependencies).
+
+Un **`vitest.config.js` dédié**, et non `vite.config.js`. Ce dernier charge trois
+plugins (Laravel, PWA, Tailwind) inutiles ici et sources de fragilité. La config de
+test se contente de l'essentiel :
+
+- `environment: 'node'` ;
+- l'alias `@ → resources/js`. **Il doit être déclaré explicitement** : dans
+  l'application, cet alias n'est pas dans `vite.config.js` — c'est
+  `laravel-vite-plugin` qui l'injecte. Vitest ne le verrait donc pas.
+
+Scripts npm : `test` (`vitest run`) et `test:watch` (`vitest`).
+
+### Deux pièges à désamorcer
+
+**`resources/js/utils.js` appelle `useToast()` au chargement du module**, pas dans
+une fonction. Importer un store — qui importe `utils` — déclencherait donc cet appel
+hors de toute application Vue. Les tests **mockent `@/utils`**, ce qu'on veut de
+toute façon : c'est ainsi qu'on vérifie que `notify` est appelé au bon moment.
+
+**`factures.js` importe le store du dashboard.** Chaque test doit donc activer une
+instance Pinia (`setActivePinia(createPinia())`) avant d'instancier un store.
+
+`axios` est mocké dans tous les tests.
+
+### Ce qu'on caractérise
+
+**Le comportement de `apiCall`**, pour chacun des cinq stores qui en ont un
+(`clients`, `taux-horaires`, `prestations`, `factures`, `auth`) :
+
+- **Succès** : ce que l'appel retourne, `loading[operation]` passe à `true` puis
+  redescend à `false`, les erreurs précédentes sont vidées.
+- **Échec 422** : `errors.validationErrors` est renseigné, **aucun toast n'est
+  émis**, et l'appel retourne une valeur *falsy*.
+- **Échec générique (500, réseau)** : `errors[operation]` est renseigné, un toast
+  est émis, l'appel retourne une valeur *falsy*.
+- **`loading` redescend à `false` même en cas d'échec** (le `finally`).
+
+Deux comportements spécifiques, à constater tels quels :
+
+- **`auth` relance l'erreur** (`throw err` dans son `catch`) : ses appelants peuvent
+  l'attraper. Les quatre autres ne relancent pas.
+- **`factures` retourne le résultat de `onSuccess`**, là où les quatre autres
+  retournent la réponse. C'est la divergence qui a produit le bug d'`addInvoice`.
+  Le test la fige : il **devra être modifié** lors du refactor, et c'est
+  précisément ce qui documentera le changement.
+
+**La logique métier** déjà vue se tromper :
+
+- `unbilledPrestations` : ne retient que les prestations sans `facture_id`.
+- `filteredInvoices` : filtres statut / client / mois, et **tri par `id`
+  décroissant** (jamais par `created_at`, que l'API renvoie au format `d/m/Y H:i:s`,
+  intriable en JavaScript).
+- Le filtre par mois retient une facture si **au moins une** de ses prestations
+  tombe dans le mois.
+- `filteredPrestations` et `isAnyFilterActive` du store des prestations.
+- `paid` écrit une clé de chargement **indexée par facture** (`paid_<id>`), et non
+  une clé unique.
+
+### La CI
+
+Un job `Tests (front)` dans `.github/workflows/ci.yml`, indépendant du job PHP :
+Node 22, `npm ci`, `npm run test`. Il bloque le merge au même titre que les tests
+PHP — sinon le filet ne sert à rien.
+
+## Tests
+
+Le livrable **est** la suite de tests. Sa vérification :
+
+- `npm run test` passe, **sans qu'aucun fichier de `resources/js/stores/` n'ait été
+  modifié** (à vérifier par `git status` : seuls des fichiers de test, la config et
+  `package.json` doivent apparaître).
+- La suite PHP (90 tests) reste verte : rien de ce qui est fait ici ne touche au
+  backend.
+- La CI de la PR est verte, avec **deux jobs** distincts et visibles.
+
+## Hors périmètre
+
+- Le refactor de `apiCall` : c'est le sous-projet suivant, et il s'appuiera sur ces
+  tests.
+- Les tests de composants (`@vue/test-utils`).
+- `dashboard.js`, qui n'a pas d'`apiCall` et gère son chargement à la main.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.0.0",
                 "vite": "^7.0.4",
-                "vite-plugin-pwa": "^1.1.0"
+                "vite-plugin-pwa": "^1.1.0",
+                "vitest": "^4.1.10"
             }
         },
         "node_modules/@apideck/better-ajv-errors": {
@@ -2865,6 +2866,13 @@
                 "win32"
             ]
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@surma/rollup-plugin-off-main-thread": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -3186,6 +3194,24 @@
                 "vue": "^2.7.0 || ^3.0.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3249,6 +3275,129 @@
             "peerDependencies": {
                 "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
                 "vue": "^3.2.25"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vue/compiler-core": {
@@ -3513,6 +3662,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/async": {
@@ -3786,6 +3945,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -4338,6 +4507,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4450,6 +4626,16 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -5944,6 +6130,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5986,6 +6186,13 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
         },
@@ -6614,6 +6821,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/simple-swizzle": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -6690,6 +6904,20 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -6955,6 +7183,23 @@
                 "node": ">=10"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6969,6 +7214,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-data-view": {
@@ -7381,6 +7636,96 @@
                 }
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
         "node_modules/vue": {
             "version": "3.5.24",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.24.tgz",
@@ -7538,6 +7883,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/workbox-background-sync": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "scripts": {
         "build": "vite build",
         "dev": "vite",
-        "generate-pwa-assets": "pwa-assets-generator"
+        "generate-pwa-assets": "pwa-assets-generator",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
@@ -12,7 +14,8 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",
         "vite": "^7.0.4",
-        "vite-plugin-pwa": "^1.1.0"
+        "vite-plugin-pwa": "^1.1.0",
+        "vitest": "^4.1.10"
     },
     "dependencies": {
         "@headlessui/vue": "^1.7.23",

--- a/resources/js/stores/auth.test.js
+++ b/resources/js/stores/auth.test.js
@@ -153,4 +153,23 @@ describe('store auth — apiCall (via updateUser, la seule operation qui l\'util
     expect(store.errors.update).toBe('Erreur serveur');
     expect(notify).toHaveBeenCalledWith('error', 'Erreur serveur');
   });
+
+  it('BUG CONNU (fige, non corrige) : updateUser ne met jamais a jour store.user', async () => {
+    // Dans updateUser(user), le parametre `user` masque la ref `user` du store.
+    // onSuccess fait `user.value = response.data.user` : ça pose .value sur le
+    // PARAMETRE (un objet simple sans .value observable), pas sur la ref du
+    // store. store.user reste donc inchange apres un updateUser reussi.
+    // Ce test fige ce comportement REEL — bugue — pour proteger le refactor.
+    // Il ne doit PAS etre "corrige" ici : le jour ou le parametre sera renomme
+    // (le vrai fix), ce test devra etre mis a jour pour affirmer l'inverse.
+    axios.put.mockResolvedValue({ data: { user: { id: 1, email: 'nouveau@mail.c' }, message: 'Mis à jour' } });
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+    store.user = { id: 1, email: 'ancien@mail.c' };
+
+    await store.updateUser({ id: 1, email: 'nouveau@mail.c' });
+
+    // store.user reste l'ANCIEN objet : la mise a jour n'a jamais eu lieu.
+    expect(store.user).toEqual({ id: 1, email: 'ancien@mail.c' });
+  });
 });

--- a/resources/js/stores/auth.test.js
+++ b/resources/js/stores/auth.test.js
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import axios from 'axios';
+import { notify } from '@/utils';
+
+vi.mock('axios');
+
+// utils.js appelle useToast() AU CHARGEMENT DU MODULE : sans ce mock, importer
+// un store planterait hors application Vue.
+vi.mock('@/utils', () => ({
+  notify: vi.fn(),
+  formatDate: vi.fn(),
+  formatNombre: vi.fn(),
+  formatEuros: vi.fn(),
+  validateEmail: vi.fn(),
+}));
+
+// auth.js, contrairement aux trois autres stores, appelle useRouter() et
+// useToast() DIRECTEMENT (pas via @/utils) au niveau racine de son setup().
+// Il faut donc mocker ces deux modules explicitement, sinon Vue avertit
+// (« inject() can only be used inside setup() ») et router/toast sont
+// inutilisables dans les chemins qui les invoquent réellement (login, logout).
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const toastMock = { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() };
+vi.mock('vue-toastification', () => ({
+  useToast: () => toastMock,
+}));
+
+/** Construit une erreur axios telle que le store la reçoit. */
+function erreurAxios(status, data = {}) {
+  return { response: { status, data } };
+}
+
+describe('store auth — login/logout (leur PROPRE gestion d\'erreur, pas apiCall)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('DECOUVERTE : login n\'appelle PAS apiCall — il a son propre try/catch', async () => {
+    // Contrairement à ce qu'on pourrait attendre (login = juste une opération
+    // apiCall de plus), login() est écrit à la main : pas de clearErrors(),
+    // pas de setLoading() via apiCall, pas de notify(), pas de rethrow.
+    // Seul updateUser() passe par apiCall dans ce store.
+    axios.get.mockResolvedValue({}); // /sanctum/csrf-cookie
+    axios.post.mockRejectedValue(erreurAxios(401, { message: 'Identifiants invalides' }));
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    const resultat = await store.login('a@b.c', 'mauvais');
+
+    // Pas de rethrow ici (à l'inverse de apiCall) : la promesse se résout.
+    expect(resultat).toBeUndefined();
+    // Le message est CODÉ EN DUR dans login, il ignore err.response.data.message.
+    expect(store.errors.login).toBe('Nom d’utilisateur ou mot de passe incorrect.');
+    // login notifie via le `toast` importé directement, jamais via notify().
+    expect(notify).not.toHaveBeenCalled();
+    expect(toastMock.error).toHaveBeenCalledWith('Échec de la connexion.');
+  });
+
+  it('login (succes) authentifie, notifie et redirige vers "/"', async () => {
+    axios.get
+      .mockResolvedValueOnce({}) // /sanctum/csrf-cookie
+      .mockResolvedValueOnce({ data: { user: { id: 1, email: 'a@b.c' } } }); // checkAuth -> /api/user
+    axios.post.mockResolvedValue({});
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    await store.login('a@b.c', 'bon-mdp');
+
+    expect(store.user).toEqual({ id: 1, email: 'a@b.c' });
+    expect(toastMock.success).toHaveBeenCalledWith('Connexion réussie !');
+    expect(pushMock).toHaveBeenCalledWith('/');
+  });
+
+  it('logout efface l\'utilisateur et redirige, meme si l\'appel API echoue', async () => {
+    // Le catch de logout est vide (`catch (e) {}`) : un échec réseau n'empêche
+    // ni la déconnexion locale, ni le toast, ni la redirection.
+    axios.post.mockRejectedValue(new Error('reseau indisponible'));
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    await store.logout();
+
+    expect(store.user).toBeNull();
+    expect(toastMock.info).toHaveBeenCalledWith('Déconnexion réussie.');
+    expect(pushMock).toHaveBeenCalledWith('/login');
+  });
+});
+
+describe('store auth — apiCall (via updateUser, la seule operation qui l\'utilise)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('retourne la reponse au succes', async () => {
+    axios.put.mockResolvedValue({ data: { user: { id: 1 }, message: 'Mis à jour' } });
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    const resultat = await store.updateUser({ id: 1 });
+
+    expect(resultat).toBeTruthy();
+    expect(resultat.data.user).toEqual({ id: 1 });
+  });
+
+  it('redescend le chargement a false apres un succes', async () => {
+    axios.put.mockResolvedValue({ data: { user: { id: 1 }, message: 'Mis à jour' } });
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    await store.updateUser({ id: 1 });
+
+    expect(store.loading.update).toBe(false);
+  });
+
+  it('redescend le chargement a false meme apres un echec', async () => {
+    axios.put.mockRejectedValue(erreurAxios(500, { message: 'Boom' }));
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    await expect(store.updateUser({ id: 1 })).rejects.toBeDefined();
+
+    expect(store.loading.update).toBe(false);
+  });
+
+  it('range un 422 dans validationErrors, SANS notifier — et relance quand meme', async () => {
+    axios.put.mockRejectedValue(erreurAxios(422, { errors: { email: ['Email invalide.'] } }));
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    await expect(store.updateUser({ id: 1 })).rejects.toBeDefined();
+
+    expect(store.errors.validationErrors).toEqual({ email: ['Email invalide.'] });
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('DIVERGENCE : apiCall relance l\'erreur apres l\'avoir traitee', async () => {
+    // Son catch se termine par `throw err;` — les quatre autres stores ne
+    // relancent pas. Ses appelants peuvent donc l'attraper. Retirer ce throw
+    // les casserait en silence.
+    axios.put.mockRejectedValue(erreurAxios(500, { message: 'Erreur serveur' }));
+    const { useAuthStore } = await import('@/stores/auth');
+    const store = useAuthStore();
+
+    await expect(store.updateUser({ id: 1 })).rejects.toBeDefined();
+
+    expect(store.errors.update).toBe('Erreur serveur');
+    expect(notify).toHaveBeenCalledWith('error', 'Erreur serveur');
+  });
+});

--- a/resources/js/stores/clients.test.js
+++ b/resources/js/stores/clients.test.js
@@ -95,4 +95,43 @@ describe('store clients — apiCall (le comportement de référence)', () => {
 
     expect(store.errors.add).toBeNull();
   });
+
+  it('monte le chargement a true PENDANT la requete', async () => {
+    // clearErrors/setLoading(operation, true) sont a l'INTERIEUR de apiCall :
+    // c'est precisement le code que ce filet doit proteger avant extraction.
+    // Les tests "redescend a false" ne suffisent pas : le `finally` pose false
+    // de toute facon, meme si la montee a true disparait du store.
+    let resoudre;
+    axios.get.mockReturnValue(new Promise((r) => { resoudre = r; }));
+    const store = useClientsStore();
+
+    const promesse = store.fetchClients();
+    // La requête est en vol : le drapeau doit être levé.
+    expect(store.loading.fetch).toBe(true);
+
+    resoudre({ data: { clients: [] } });
+    await promesse;
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('DETTE FIGEE (non corrigee) : errors.validationErrors n\'est jamais vide, meme apres un succes ulterieur', async () => {
+    // clearErrors(operation) ne remet a null que errors[operation]. errors.validationErrors
+    // n'est jamais reinitialise nulle part. Un 422 laisse donc validationErrors pose
+    // indefiniment, y compris apres un appel reussi qui suit — un scenario reel : 422 sur
+    // addClient, l'utilisateur corrige, reenregistre avec succes, et validationErrors peut
+    // encore rejouer des erreurs de champ perimees.
+    // Ce test fige le comportement REEL comme une dette ; il ne doit PAS etre "corrige" ici.
+    const store = useClientsStore();
+
+    axios.post.mockRejectedValueOnce(erreurAxios(422, { errors: { nom: ['Le nom est obligatoire.'] } }));
+    await store.addClient({ nom: '' });
+    expect(store.errors.validationErrors).toEqual({ nom: ['Le nom est obligatoire.'] });
+
+    axios.post.mockResolvedValueOnce({ data: { client: { id: 1 }, message: 'Créé' } });
+    await store.addClient({ nom: 'EBS' });
+
+    // Le succes suivant N'A PAS vide validationErrors : la dette est figee ici.
+    expect(store.errors.validationErrors).toEqual({ nom: ['Le nom est obligatoire.'] });
+  });
 });

--- a/resources/js/stores/clients.test.js
+++ b/resources/js/stores/clients.test.js
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import axios from 'axios';
+import { useClientsStore } from '@/stores/clients';
+import { notify } from '@/utils';
+
+vi.mock('axios');
+
+// utils.js appelle useToast() AU CHARGEMENT DU MODULE : sans ce mock, importer
+// un store planterait hors application Vue.
+vi.mock('@/utils', () => ({
+  notify: vi.fn(),
+  formatDate: vi.fn(),
+  formatNombre: vi.fn(),
+  formatEuros: vi.fn(),
+  validateEmail: vi.fn(),
+}));
+
+/** Construit une erreur axios telle que le store la reçoit. */
+function erreurAxios(status, data = {}) {
+  return { response: { status, data } };
+}
+
+describe('store clients — apiCall (le comportement de référence)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('retourne la reponse au succes', async () => {
+    axios.get.mockResolvedValue({ data: { clients: [{ id: 1, nom: 'EBS' }] } });
+    const store = useClientsStore();
+
+    const resultat = await store.fetchClients();
+
+    // Le comportement de référence : apiCall retourne la RÉPONSE.
+    expect(resultat).toBeTruthy();
+    expect(resultat.data.clients).toHaveLength(1);
+    expect(store.clients).toHaveLength(1);
+  });
+
+  it('redescend le chargement a false apres un succes', async () => {
+    axios.get.mockResolvedValue({ data: { clients: [] } });
+    const store = useClientsStore();
+
+    await store.fetchClients();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('redescend le chargement a false meme apres un echec', async () => {
+    axios.get.mockRejectedValue(erreurAxios(500, { message: 'Boom' }));
+    const store = useClientsStore();
+
+    await store.fetchClients();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('range un 422 dans validationErrors, SANS notifier', async () => {
+    axios.post.mockRejectedValue(
+      erreurAxios(422, { errors: { nom: ['Le nom est obligatoire.'] } })
+    );
+    const store = useClientsStore();
+
+    const resultat = await store.addClient({ nom: '' });
+
+    expect(store.errors.validationErrors).toEqual({ nom: ['Le nom est obligatoire.'] });
+    // Un 422 ne déclenche AUCUN toast : c'est ce qui a rendu un bloc d'erreur
+    // inaffichable dans la modale de facture.
+    expect(notify).not.toHaveBeenCalled();
+    expect(resultat).toBeFalsy();
+  });
+
+  it('range les autres erreurs dans errors[operation] ET notifie', async () => {
+    axios.post.mockRejectedValue(erreurAxios(500, { message: 'Erreur serveur' }));
+    const store = useClientsStore();
+
+    const resultat = await store.addClient({ nom: 'EBS' });
+
+    expect(store.errors.add).toBe('Erreur serveur');
+    expect(notify).toHaveBeenCalledWith('error', 'Erreur serveur');
+    expect(resultat).toBeFalsy();
+  });
+
+  it('vide l\'erreur precedente de l\'operation avant un nouvel appel', async () => {
+    const store = useClientsStore();
+
+    axios.post.mockRejectedValueOnce(erreurAxios(500, { message: 'Erreur serveur' }));
+    await store.addClient({ nom: 'EBS' });
+    expect(store.errors.add).toBe('Erreur serveur');
+
+    axios.post.mockResolvedValueOnce({ data: { client: { id: 1 }, message: 'Créé' } });
+    await store.addClient({ nom: 'EBS' });
+
+    expect(store.errors.add).toBeNull();
+  });
+});

--- a/resources/js/stores/factures.test.js
+++ b/resources/js/stores/factures.test.js
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import axios from 'axios';
+import { useInvoicesStore } from '@/stores/factures';
+import { notify } from '@/utils';
+
+vi.mock('axios');
+
+// utils.js appelle useToast() AU CHARGEMENT DU MODULE : sans ce mock, importer
+// un store planterait hors application Vue.
+vi.mock('@/utils', () => ({
+  notify: vi.fn(),
+  formatDate: vi.fn(),
+  formatNombre: vi.fn(),
+  formatEuros: vi.fn(),
+  validateEmail: vi.fn(),
+}));
+
+/** Construit une erreur axios telle que le store la reçoit. */
+function erreurAxios(status, data = {}) {
+  return { response: { status, data } };
+}
+
+// factures.js importe useDashboardStore : setActivePinia(createPinia()) suffit
+// a le faire s'instancier normalement, pas besoin de le mocker.
+
+describe('store factures — apiCall (la divergence)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('fetchInvoices retourne la reponse au succes (comportement standard, comme onSuccess ne retourne rien)', async () => {
+    axios.get.mockResolvedValue({ data: { factures: [{ id: 1 }] } });
+    const store = useInvoicesStore();
+
+    const resultat = await store.fetchInvoices();
+
+    // fetchInvoices : onSuccess ne retourne rien (undefined), donc apiCall
+    // renvoie `onSuccess(response)` = undefined, PAS la réponse axios.
+    // C'est déjà une trace de la divergence : seule addInvoice s'en sort
+    // grâce à son `return true` explicite.
+    expect(resultat).toBeUndefined();
+    expect(store.invoices).toHaveLength(1);
+  });
+
+  it('redescend le chargement a false apres un succes', async () => {
+    axios.get.mockResolvedValue({ data: { factures: [] } });
+    const store = useInvoicesStore();
+
+    await store.fetchInvoices();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('redescend le chargement a false meme apres un echec', async () => {
+    axios.get.mockRejectedValue(erreurAxios(500, { message: 'Boom' }));
+    const store = useInvoicesStore();
+
+    await store.fetchInvoices();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('range un 422 dans validationErrors, SANS notifier', async () => {
+    axios.post.mockRejectedValue(
+      erreurAxios(422, { errors: { prestations: ['Déjà facturée.'] } })
+    );
+    const store = useInvoicesStore();
+
+    await store.addInvoice({ prestations: [1] });
+
+    expect(store.errors.validationErrors).toEqual({ prestations: ['Déjà facturée.'] });
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('range les autres erreurs dans errors[operation] ET notifie', async () => {
+    axios.post.mockRejectedValue(erreurAxios(500, { message: 'Erreur serveur' }));
+    const store = useInvoicesStore();
+
+    const resultat = await store.addInvoice({ prestations: [1] });
+
+    expect(store.errors.add).toBe('Erreur serveur');
+    expect(notify).toHaveBeenCalledWith('error', 'Erreur serveur');
+    expect(resultat).toBeFalsy();
+  });
+
+  it('DIVERGENCE : apiCall retourne le resultat de onSuccess, pas la reponse', async () => {
+    // Les quatre autres stores font `if (onSuccess) onSuccess(response); return response;`
+    // Celui-ci fait `return onSuccess ? onSuccess(response) : response;`
+    // addInvoice retourne donc ce que retourne SON onSuccess — un `true` explicite,
+    // ajouté précisément parce que sans lui l'appelant recevait `undefined` et ne
+    // pouvait pas distinguer un succès d'un échec.
+    axios.post.mockResolvedValue({ data: { facture: { id: 1 }, message: 'Créée' } });
+    const store = useInvoicesStore();
+
+    const resultat = await store.addInvoice({ prestations: [1] });
+
+    expect(resultat).toBe(true); // et NON la réponse axios
+  });
+
+  it('addInvoice retourne une valeur falsy en cas d\'echec', async () => {
+    axios.post.mockRejectedValue({ response: { status: 422, data: { errors: { prestations: ['Déjà facturée.'] } } } });
+    const store = useInvoicesStore();
+
+    const resultat = await store.addInvoice({ prestations: [1] });
+
+    // C'est ce qui permet à la modale de ne PAS se fermer sur un échec.
+    expect(resultat).toBeFalsy();
+    expect(store.errors.validationErrors).toEqual({ prestations: ['Déjà facturée.'] });
+  });
+
+  it('paid indexe la cle de chargement par facture', async () => {
+    // Une clé unique ("paid") ferait clignoter le bouton de TOUTES les lignes.
+    axios.patch.mockResolvedValue({ data: { facture: { id: 12, statut: 'payé' }, message: 'Payée' } });
+    const store = useInvoicesStore();
+
+    await store.paid(12);
+
+    expect(store.loading.paid_12).toBe(false); // la clé existe, indexée
+    expect(store.loading.paid).toBeUndefined(); // et surtout : PAS de clé globale
+  });
+
+  it('getInvoicePdf gere ses erreurs via son propre onError, pas la branche generique de apiCall', async () => {
+    // getInvoicePdf fournit un onError dédié : la branche générique
+    // (validationErrors / errors[operation] + notify) est donc court-circuitée.
+    axios.get.mockRejectedValue({
+      response: { status: 422, data: {}, headers: {} },
+    });
+    const store = useInvoicesStore();
+
+    // Autre bizarrerie propre a apiCall(factures) : dans le catch, `onError(err)`
+    // est appelé SANS await. Le message d'erreur qu'il calcule (via un `await`
+    // interne) finit bien dans errors.pdf/notify, mais la valeur de retour de
+    // ce onError ('') n'est elle-même jamais renvoyée par apiCall : le catch ne
+    // fait rien de son résultat. getInvoicePdf résout donc à `undefined` sur
+    // échec, pas à la chaîne '' que onError retourne.
+    const resultat = await store.getInvoicePdf(1);
+
+    expect(resultat).toBeUndefined();
+    expect(store.errors.pdf).toBe('Votre profil est incomplet. Complétez vos informations dans les paramètres.');
+    // La branche générique n'est jamais atteinte : pas de validationErrors.
+    expect(store.errors.validationErrors).toBeUndefined();
+    expect(notify).toHaveBeenCalledWith('error', store.errors.pdf);
+  });
+});

--- a/resources/js/stores/factures.test.js
+++ b/resources/js/stores/factures.test.js
@@ -121,6 +121,40 @@ describe('store factures — apiCall (la divergence)', () => {
     expect(store.loading.paid).toBeUndefined(); // et surtout : PAS de clé globale
   });
 
+  it('monte le chargement a true PENDANT la requete (fetch)', async () => {
+    // Meme lacune que sur le store clients : les tests "redescend a false"
+    // n'attrapent pas la disparition de setLoading(operation, true), qui vit
+    // a l'interieur d'apiCall, en amont du try/finally.
+    let resoudre;
+    axios.get.mockReturnValue(new Promise((r) => { resoudre = r; }));
+    const store = useInvoicesStore();
+
+    const promesse = store.fetchInvoices();
+    expect(store.loading.fetch).toBe(true);
+
+    resoudre({ data: { factures: [] } });
+    await promesse;
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('monte loading.paid_<id> (cle indexee) a true PENDANT la requete', async () => {
+    // Le composant teste `loading[\`paid_${id}\`] === true` : c'est bien cette
+    // cle indexee, et non une cle globale "paid", qui doit monter a true en vol.
+    let resoudre;
+    axios.patch.mockReturnValue(new Promise((r) => { resoudre = r; }));
+    const store = useInvoicesStore();
+
+    const promesse = store.paid(12);
+    expect(store.loading.paid_12).toBe(true);
+    expect(store.loading.paid).toBeUndefined();
+
+    resoudre({ data: { facture: { id: 12, statut: 'payé' }, message: 'Payée' } });
+    await promesse;
+
+    expect(store.loading.paid_12).toBe(false);
+  });
+
   it('getInvoicePdf gere ses erreurs via son propre onError, pas la branche generique de apiCall', async () => {
     // getInvoicePdf fournit un onError dédié : la branche générique
     // (validationErrors / errors[operation] + notify) est donc court-circuitée.

--- a/resources/js/stores/logique-metier.test.js
+++ b/resources/js/stores/logique-metier.test.js
@@ -192,9 +192,12 @@ describe('store factures — logique metier', () => {
       ];
       await nextTick();
 
-      expect(() => {
-        store.updateFilters({ statut: '', client_id: 1, month_year: '2026-04' });
-      }).not.toThrow();
+      // Pas d'assertion `.not.toThrow()` ici : updateFilters ne fait qu'une
+      // affectation, le filtrage a lieu plus tard dans le watcher — une telle
+      // assertion ne pourrait jamais echouer (tautologie). La regression est
+      // attrapee par l'assertion finale ci-dessous, qui exerce reellement le
+      // filtrage sur les factures 4 et 5.
+      store.updateFilters({ statut: '', client_id: 1, month_year: '2026-04' });
       await nextTick();
 
       // Ni la 4 (prestations vide) ni la 5 (prestations absent) ne matchent

--- a/resources/js/stores/logique-metier.test.js
+++ b/resources/js/stores/logique-metier.test.js
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
+import axios from 'axios';
+import { usePrestationsStore } from '@/stores/prestations';
+import { useInvoicesStore } from '@/stores/factures';
+
+vi.mock('axios');
+
+// utils.js appelle useToast() AU CHARGEMENT DU MODULE : sans ce mock, importer
+// un store planterait hors application Vue.
+vi.mock('@/utils', () => ({
+  notify: vi.fn(),
+  formatDate: vi.fn(),
+  formatNombre: vi.fn(),
+  formatEuros: vi.fn(),
+  validateEmail: vi.fn(),
+}));
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+});
+
+describe('store prestations — logique metier', () => {
+  describe('unbilledPrestations', () => {
+    it('ne retient que les prestations dont facture_id est null', () => {
+      const store = usePrestationsStore();
+
+      store.prestations = [
+        { id: 1, facture_id: null },
+        { id: 2, facture_id: 7 },
+        { id: 3, facture_id: null },
+      ];
+
+      expect(store.unbilledPrestations.map(p => p.id)).toEqual([1, 3]);
+    });
+  });
+
+  describe('filteredPrestations', () => {
+    const prestationsDeBase = [
+      { id: 1, date: '2026-03-05', client_id: 1, taux_horaire_id: 1 },
+      { id: 2, date: '2026-03-20', client_id: 2, taux_horaire_id: 2 },
+      { id: 3, date: '2026-04-01', client_id: 1, taux_horaire_id: 2 },
+    ];
+
+    it('filtre par month_year', async () => {
+      const store = usePrestationsStore();
+      store.prestations = prestationsDeBase;
+      await nextTick();
+
+      store.updateFilters({ month_year: '2026-03', client_id: '', taux_horaire_id: '' });
+      await nextTick();
+
+      expect(store.filteredPrestations.map(p => p.id)).toEqual([1, 2]);
+    });
+
+    it('filtre par client_id', async () => {
+      const store = usePrestationsStore();
+      store.prestations = prestationsDeBase;
+      await nextTick();
+
+      store.updateFilters({ month_year: '', client_id: 1, taux_horaire_id: '' });
+      await nextTick();
+
+      expect(store.filteredPrestations.map(p => p.id)).toEqual([1, 3]);
+    });
+
+    it('filtre par taux_horaire_id', async () => {
+      const store = usePrestationsStore();
+      store.prestations = prestationsDeBase;
+      await nextTick();
+
+      store.updateFilters({ month_year: '', client_id: '', taux_horaire_id: 2 });
+      await nextTick();
+
+      expect(store.filteredPrestations.map(p => p.id)).toEqual([2, 3]);
+    });
+
+    it('combine les filtres (ET logique)', async () => {
+      const store = usePrestationsStore();
+      store.prestations = prestationsDeBase;
+      await nextTick();
+
+      store.updateFilters({ month_year: '2026-03', client_id: 2, taux_horaire_id: '' });
+      await nextTick();
+
+      expect(store.filteredPrestations.map(p => p.id)).toEqual([2]);
+    });
+  });
+
+  describe('isAnyFilterActive', () => {
+    it('est false quand tous les filtres sont des chaines vides', () => {
+      const store = usePrestationsStore();
+
+      store.updateFilters({ month_year: '', client_id: '', taux_horaire_id: '' });
+
+      expect(store.isAnyFilterActive).toBe(false);
+    });
+
+    it('est true des qu\'un seul filtre est renseigne', () => {
+      const store = usePrestationsStore();
+
+      store.updateFilters({ month_year: '2026-03', client_id: '', taux_horaire_id: '' });
+
+      expect(store.isAnyFilterActive).toBe(true);
+    });
+  });
+});
+
+describe('store factures — logique metier', () => {
+  describe('filteredInvoices — tri', () => {
+    it('trie par id decroissant, meme quand l\'ordre du tableau source le contredit', async () => {
+      const store = useInvoicesStore();
+
+      // L'ordre source (2, 5, 1) contredit a la fois l'ordre croissant ET
+      // l'ordre decroissant : seul un vrai tri produit [5, 2, 1].
+      store.invoices = [
+        { id: 2, statut: 'envoyée', prestations: [] },
+        { id: 5, statut: 'envoyée', prestations: [] },
+        { id: 1, statut: 'envoyée', prestations: [] },
+      ];
+      await nextTick();
+
+      expect(store.filteredInvoices.map(i => i.id)).toEqual([5, 2, 1]);
+    });
+  });
+
+  describe('filteredInvoices — filtres', () => {
+    const facturesDeBase = [
+      {
+        id: 1,
+        statut: 'payée',
+        prestations: [{ client_id: 1, date: '2026-03-10' }],
+      },
+      {
+        id: 2,
+        statut: 'envoyée',
+        prestations: [{ client_id: 2, date: '2026-04-05' }],
+      },
+      {
+        id: 3,
+        statut: 'envoyée',
+        prestations: [
+          { client_id: 1, date: '2026-01-01' },
+          { client_id: 1, date: '2026-04-15' },
+        ],
+      },
+    ];
+
+    it('filtre par statut', async () => {
+      const store = useInvoicesStore();
+      store.invoices = facturesDeBase;
+      await nextTick();
+
+      store.updateFilters({ statut: 'envoyée', client_id: '', month_year: '' });
+      await nextTick();
+
+      expect(store.filteredInvoices.map(i => i.id).sort()).toEqual([2, 3]);
+    });
+
+    it('filtre par client, en ne regardant que la premiere prestation de la facture', async () => {
+      const store = useInvoicesStore();
+      store.invoices = facturesDeBase;
+      await nextTick();
+
+      store.updateFilters({ statut: '', client_id: 1, month_year: '' });
+      await nextTick();
+
+      expect(store.filteredInvoices.map(i => i.id).sort()).toEqual([1, 3]);
+    });
+
+    it('filtre par mois : retenue si AU MOINS UNE prestation tombe dans le mois', async () => {
+      const store = useInvoicesStore();
+      store.invoices = facturesDeBase;
+      await nextTick();
+
+      // La facture 3 n'a sa premiere prestation qu'en janvier, mais sa
+      // seconde tombe en avril : elle doit malgre tout etre retenue.
+      store.updateFilters({ statut: '', client_id: '', month_year: '2026-04' });
+      await nextTick();
+
+      expect(store.filteredInvoices.map(i => i.id).sort()).toEqual([2, 3]);
+    });
+
+    it('une facture sans prestation ne fait pas planter les filtres', async () => {
+      const store = useInvoicesStore();
+      store.invoices = [
+        ...facturesDeBase,
+        { id: 4, statut: 'envoyée', prestations: [] },
+        { id: 5, statut: 'envoyée' }, // prestations meme absent du payload
+      ];
+      await nextTick();
+
+      expect(() => {
+        store.updateFilters({ statut: '', client_id: 1, month_year: '2026-04' });
+      }).not.toThrow();
+      await nextTick();
+
+      // Ni la 4 (prestations vide) ni la 5 (prestations absent) ne matchent
+      // le filtre client/mois, mais elles ne font pas planter le calcul.
+      expect(store.filteredInvoices.map(i => i.id)).toEqual([3]);
+    });
+  });
+});

--- a/resources/js/stores/prestations.test.js
+++ b/resources/js/stores/prestations.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import axios from 'axios';
+import { usePrestationsStore } from '@/stores/prestations';
+import { notify } from '@/utils';
+
+vi.mock('axios');
+
+// utils.js appelle useToast() AU CHARGEMENT DU MODULE : sans ce mock, importer
+// un store planterait hors application Vue.
+vi.mock('@/utils', () => ({
+  notify: vi.fn(),
+  formatDate: vi.fn(),
+  formatNombre: vi.fn(),
+  formatEuros: vi.fn(),
+  validateEmail: vi.fn(),
+}));
+
+/** Construit une erreur axios telle que le store la reçoit. */
+function erreurAxios(status, data = {}) {
+  return { response: { status, data } };
+}
+
+describe('store prestations — apiCall (identique a clients)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('retourne la reponse au succes', async () => {
+    axios.get.mockResolvedValue({ data: { prestations: [{ id: 1, heures: 7 }] } });
+    const store = usePrestationsStore();
+
+    const resultat = await store.fetchPrestations();
+
+    expect(resultat).toBeTruthy();
+    expect(resultat.data.prestations).toHaveLength(1);
+    expect(store.prestations).toHaveLength(1);
+  });
+
+  it('redescend le chargement a false apres un succes', async () => {
+    axios.get.mockResolvedValue({ data: { prestations: [] } });
+    const store = usePrestationsStore();
+
+    await store.fetchPrestations();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('redescend le chargement a false meme apres un echec', async () => {
+    axios.get.mockRejectedValue(erreurAxios(500, { message: 'Boom' }));
+    const store = usePrestationsStore();
+
+    await store.fetchPrestations();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('range un 422 dans validationErrors, SANS notifier', async () => {
+    axios.post.mockRejectedValue(
+      erreurAxios(422, { errors: { heures: ['Les heures sont obligatoires.'] } })
+    );
+    const store = usePrestationsStore();
+
+    const resultat = await store.addPrestation({ heures: '' });
+
+    expect(store.errors.validationErrors).toEqual({ heures: ['Les heures sont obligatoires.'] });
+    expect(notify).not.toHaveBeenCalled();
+    expect(resultat).toBeFalsy();
+  });
+
+  it('range les autres erreurs dans errors[operation] ET notifie', async () => {
+    axios.post.mockRejectedValue(erreurAxios(500, { message: 'Erreur serveur' }));
+    const store = usePrestationsStore();
+
+    const resultat = await store.addPrestation({ heures: 7 });
+
+    expect(store.errors.add).toBe('Erreur serveur');
+    expect(notify).toHaveBeenCalledWith('error', 'Erreur serveur');
+    expect(resultat).toBeFalsy();
+  });
+
+  it('vide l\'erreur precedente de l\'operation avant un nouvel appel', async () => {
+    const store = usePrestationsStore();
+
+    axios.post.mockRejectedValueOnce(erreurAxios(500, { message: 'Erreur serveur' }));
+    await store.addPrestation({ heures: 7 });
+    expect(store.errors.add).toBe('Erreur serveur');
+
+    axios.post.mockResolvedValueOnce({ data: { prestation: { id: 1 }, message: 'Créée' } });
+    await store.addPrestation({ heures: 7 });
+
+    expect(store.errors.add).toBeNull();
+  });
+});

--- a/resources/js/stores/taux-horaires.test.js
+++ b/resources/js/stores/taux-horaires.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import axios from 'axios';
+import { useTauxHorairesStore } from '@/stores/taux-horaires';
+import { notify } from '@/utils';
+
+vi.mock('axios');
+
+// utils.js appelle useToast() AU CHARGEMENT DU MODULE : sans ce mock, importer
+// un store planterait hors application Vue.
+vi.mock('@/utils', () => ({
+  notify: vi.fn(),
+  formatDate: vi.fn(),
+  formatNombre: vi.fn(),
+  formatEuros: vi.fn(),
+  validateEmail: vi.fn(),
+}));
+
+/** Construit une erreur axios telle que le store la reçoit. */
+function erreurAxios(status, data = {}) {
+  return { response: { status, data } };
+}
+
+describe('store taux-horaires — apiCall (identique a clients)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('retourne la reponse au succes', async () => {
+    axios.get.mockResolvedValue({ data: { taux_horaires: [{ id: 1, taux: 50 }] } });
+    const store = useTauxHorairesStore();
+
+    const resultat = await store.fetchTauxHoraires();
+
+    expect(resultat).toBeTruthy();
+    expect(resultat.data.taux_horaires).toHaveLength(1);
+    expect(store.tauxHoraires).toHaveLength(1);
+  });
+
+  it('redescend le chargement a false apres un succes', async () => {
+    axios.get.mockResolvedValue({ data: { taux_horaires: [] } });
+    const store = useTauxHorairesStore();
+
+    await store.fetchTauxHoraires();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('redescend le chargement a false meme apres un echec', async () => {
+    axios.get.mockRejectedValue(erreurAxios(500, { message: 'Boom' }));
+    const store = useTauxHorairesStore();
+
+    await store.fetchTauxHoraires();
+
+    expect(store.loading.fetch).toBe(false);
+  });
+
+  it('range un 422 dans validationErrors, SANS notifier', async () => {
+    axios.post.mockRejectedValue(
+      erreurAxios(422, { errors: { taux: ['Le taux est obligatoire.'] } })
+    );
+    const store = useTauxHorairesStore();
+
+    const resultat = await store.addTauxHoraire({ taux: '' });
+
+    expect(store.errors.validationErrors).toEqual({ taux: ['Le taux est obligatoire.'] });
+    expect(notify).not.toHaveBeenCalled();
+    expect(resultat).toBeFalsy();
+  });
+
+  it('range les autres erreurs dans errors[operation] ET notifie', async () => {
+    axios.post.mockRejectedValue(erreurAxios(500, { message: 'Erreur serveur' }));
+    const store = useTauxHorairesStore();
+
+    const resultat = await store.addTauxHoraire({ taux: 50 });
+
+    expect(store.errors.add).toBe('Erreur serveur');
+    expect(notify).toHaveBeenCalledWith('error', 'Erreur serveur');
+    expect(resultat).toBeFalsy();
+  });
+
+  it('vide l\'erreur precedente de l\'operation avant un nouvel appel', async () => {
+    const store = useTauxHorairesStore();
+
+    axios.post.mockRejectedValueOnce(erreurAxios(500, { message: 'Erreur serveur' }));
+    await store.addTauxHoraire({ taux: 50 });
+    expect(store.errors.add).toBe('Erreur serveur');
+
+    axios.post.mockResolvedValueOnce({ data: { taux_horaire: { id: 1 }, message: 'Créé' } });
+    await store.addTauxHoraire({ taux: 50 });
+
+    expect(store.errors.add).toBeNull();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Config dédiée, distincte de vite.config.js : celui-ci charge trois plugins
+// (Laravel, PWA, Tailwind) inutiles ici et sources de fragilité.
+export default defineConfig({
+  test: {
+    // Aucun rendu de composant : les stores n'ont pas besoin d'un DOM.
+    environment: 'node',
+    include: ['resources/js/**/*.test.js'],
+  },
+  resolve: {
+    alias: {
+      // Dans l'application, cet alias est injecté par laravel-vite-plugin,
+      // et non déclaré dans vite.config.js. Vitest ne le verrait donc pas.
+      '@': fileURLToPath(new URL('./resources/js', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
Le projet n'avait **aucun test front**. Toute la logique des stores Pinia — appels API, chargement, erreurs, notifications, filtres, tris — n'était vérifiée que par la lecture et par un parcours manuel.

Ce trou a un coût mesurable. Rien que dans les PR récentes, il a laissé passer : `addInvoice` qui ne retournait **rien** (la modale se fermait donc même en cas d'échec, effaçant la sélection) ; un bloc d'erreur qui **ne pouvait jamais s'afficher** (les 422 atterrissent dans `errors.validationErrors`, sans toast, alors que le composant lisait `errors.add`) ; et `loading.paid`, une clé partagée qui faisait clignoter le bouton de toutes les factures. **Aucun n'était visible au build.**

## Pourquoi maintenant, et dans cet ordre

On veut extraire `apiCall`, dupliqué dans cinq stores dont un a divergé. Refactorer cinq stores sans filet reproduirait exactement la méthode qui a produit ces bugs.

Ces tests sont des tests de **caractérisation** : ils décrivent ce que le code **fait**, pas ce qu'il devrait faire. C'est contre-intuitif, mais c'est le seul filet qui vaille : un test décrivant le comportement *souhaité* ne prouve rien tant que le refactor n'est pas fait, tandis qu'un test décrivant le comportement *existant* devient un juge dès qu'on touche au code — ce qui reste vert n'a pas bougé, ce qui casse est exactement ce qu'on a changé.

**Critère de réussite, vérifié mécaniquement : aucun fichier `resources/js/stores/*.js` n'a été modifié.** Les tests attestent du code réel.

## Ce que ça apporte

| | |
|---|---|
| Vitest 4 | `environment: 'node'`, pas de jsdom (aucun rendu à simuler) |
| 52 tests | `apiCall` des 5 stores, logique métier (filtres, tris, sélections) |
| Job CI | « Tests (front) », distinct du job PHP |

Les deux **divergences** sont figées telles quelles : `factures` retourne le résultat de `onSuccess` là où les autres retournent la réponse, et `auth` relance l'erreur. Ces tests **devront être modifiés** par le refactor — et c'est précisément ce qui documentera le changement.

## Ce que l'exercice a révélé

**Ma compréhension du code était fausse sur plusieurs points**, et les tests l'ont corrigée avant que le refactor ne s'appuie dessus :

- `auth.login()` **n'utilise pas `apiCall`** — c'est du code écrit à la main, qui ne relance rien, code son message en dur et notifie via un toast importé directement. Seul `updateUser()` passe par `apiCall`.
- `apiCall` (factures) appelle `onError` **sans `await`** : `getInvoicePdf` résout à `undefined` en cas d'échec.
- `fetchInvoices` retourne `undefined` au lieu de la réponse — la divergence dépasse `addInvoice`.

## Le filet a lui-même été mis à l'épreuve

La revue n'a pas jugé les tests en les lisant : elle a **cassé les stores un par un** pour voir si la suite l'attrapait. Supprimer le tri → 1 échec. Retirer le `throw` d'`auth` → 3 échecs. Aligner la divergence de `factures` → 2 échecs. Retirer un `notify` → 1 échec.

**Et elle a trouvé un trou béant** : supprimer `setLoading(operation, true)` — la ligne qui *monte* le drapeau de chargement — laissait les 47 tests verts. Mes tests n'assertaient que le `false` final, que le `finally` pose de toute façon. Or cette ligne pilote tous les spinners et boutons désactivés de l'app : le refactor aurait pu la perdre avec une CI verte, et les spinners seraient morts en silence (double-soumission possible sur « Créer une facture »).

Un test capture désormais le drapeau **en vol**. Preuve : retirer `setLoading(operation, true)` fait rougir la suite.

Deux comportements réels, non figés, ont aussi été capturés comme dettes : `updateUser()` ne met **jamais** à jour `store.user` (le paramètre masque la ref du store), et `errors.validationErrors` n'est **jamais vidé**.

## Vérifications

- `npm run test` → **52 tests verts**.
- `php artisan test` → 90 verts (backend intact).
- `git diff main -- resources/js/stores/*.js` → **vide** : aucun store touché.

## À faire hors code

`main` **n'a aucune protection de branche** : ni « Tests (Pest) » ni « Tests (front) » n'est un check requis, donc le bouton Merge reste vert même sur CI rouge. Le déploiement, lui, est bien bloqué (`deploy.yml` attend le succès de la CI). À activer dans les réglages GitHub.

Spec et plan : `docs/superpowers/specs/2026-07-13-tests-front-stores-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj