### PR TITLE
Extraire apiCall : une seule source de vérité pour les appels API

### DIFF
--- a/docs/superpowers/plans/2026-07-13-apicall-partage.md
+++ b/docs/superpowers/plans/2026-07-13-apicall-partage.md
@@ -1,0 +1,409 @@
+# Extraire `apiCall` en fabrique partagée — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Supprimer les cinq copies de `apiCall` / `clearErrors` / `setLoading` (~140 lignes dupliquées) au profit d'une fabrique unique, en alignant au passage le store des factures, qui avait divergé.
+
+**Architecture :** Une fabrique `creerApiCall({ errors, loading, relancerLesErreurs })` rend à chaque store son `apiCall`, `clearErrors` et `setLoading`. Elle porte le comportement des quatre stores conformes ; c'est `factures` qui s'aligne. Les 52 tests de caractérisation (PR #29) sont le juge : ce qui reste vert n'a pas bougé.
+
+**Tech Stack :** Vue 3, Pinia, Vitest 4.
+
+## Global Constraints
+
+- Spec de référence : `docs/superpowers/specs/2026-07-13-apicall-partage-design.md`
+- **Le filet définit ce qui a le droit de casser.** Les SEULS tests autorisés à rougir sont ceux de `resources/js/stores/factures.test.js` qui décrivent ses divergences. **Tout autre test rouge est une régression** : on reprend le CODE, jamais le test. « Ajuster » un test jusqu'au vert est une faute — le refactor n'aurait alors rien prouvé.
+- **Deux dettes sont figées par des tests et NE DOIVENT PAS être corrigées ici** :
+  1. `auth.updateUser()` ne met jamais à jour `store.user` (le paramètre `user` masque la ref du store). Son test l'atteste — il doit **rester vert**.
+  2. `errors.validationErrors` n'est jamais vidé par `clearErrors`. Son test l'atteste — il doit **rester vert**.
+  Les corriger ici mélangerait un refactor (aucun changement de comportement) et des corrections de bugs. Si l'un de ces tests casse, c'est qu'un comportement a changé sans qu'on l'ait décidé.
+- **Le comportement de référence est celui des quatre stores conformes** : `if (onSuccess) onSuccess(response); return response;`. C'est `factures` qui s'aligne, pas l'inverse.
+- **`auth.login()` n'utilise PAS `apiCall`** (code écrit à la main, ne relance rien, message en dur, toast direct). Seul `updateUser()` y passe — et c'est lui, et lui seul, que le `throw` du `catch` sert. Ne touche pas à `login`.
+- `dashboard.js` n'a pas d'`apiCall` : il reste à l'écart.
+- Vérification : `npm run test` (52 tests) et `php artisan test` (90 tests, backend intact — rien ici ne le touche).
+- Commits en français, format `type: description`.
+
+---
+
+### Task 1 : La fabrique, et le store de référence
+
+On crée la fabrique et on migre `clients` — le store dont l'`apiCall` **est** le comportement de référence. **Ses tests doivent rester verts sans qu'on y touche** : c'est la preuve que la fabrique reproduit fidèlement l'original.
+
+**Files:**
+- Create: `resources/js/stores/apiCall.js`
+- Modify: `resources/js/stores/clients.js`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: `creerApiCall({ errors, loading, relancerLesErreurs })` → `{ apiCall, clearErrors, setLoading }`. Les tâches 2, 3 et 4 l'utilisent.
+
+- [ ] **Step 1: Créer la fabrique**
+
+Créer `resources/js/stores/apiCall.js` :
+
+```js
+import { notify } from '@/utils';
+
+/**
+ * Fabrique l'enveloppe des appels API d'un store : chargement, erreurs,
+ * notifications.
+ *
+ * Cette fonction était copiée dans cinq stores. Trois copies étaient identiques
+ * caractère pour caractère, une avait divergé — et cette divergence a produit un
+ * bug réel (une modale qui se fermait sur un échec, effaçant la saisie).
+ *
+ * @param {object} refs
+ * @param {import('vue').Ref<object>} refs.errors   Les erreurs du store, par opération.
+ * @param {import('vue').Ref<object>} refs.loading  Les états de chargement, par opération.
+ * @param {boolean} [refs.relancerLesErreurs=false] Relance l'erreur après l'avoir
+ *   traitée. Seul le store `auth` l'active : son `updateUser()` compte dessus.
+ */
+export function creerApiCall({ errors, loading, relancerLesErreurs = false }) {
+  function clearErrors(operation) {
+    if (operation) {
+      errors.value[operation] = null;
+    } else {
+      errors.value = {};
+    }
+  }
+
+  function setLoading(operation, state) {
+    loading.value[operation] = state;
+  }
+
+  /**
+   * @param {object} options
+   * @param {string} options.operation   Clé sous laquelle chargement et erreur sont rangés.
+   * @param {Function} options.request   L'appel axios.
+   * @param {Function} [options.onSuccess] Effets de bord au succès. Sa valeur de
+   *   retour est IGNORÉE : apiCall retourne toujours la réponse.
+   * @param {Function} [options.onError]   Gestion d'erreur sur mesure, qui remplace
+   *   le traitement par défaut. Seul `getInvoicePdf` en a besoin (réponse en blob).
+   * @returns {Promise<*>} La réponse au succès, `undefined` en cas d'échec.
+   */
+  async function apiCall({ operation, request, onSuccess, onError }) {
+    clearErrors(operation);
+    setLoading(operation, true);
+
+    try {
+      const response = await request();
+      if (onSuccess) onSuccess(response);
+      return response;
+    } catch (err) {
+      if (onError) {
+        // `await` : onError peut être asynchrone (getInvoicePdf lit un blob).
+        // Sans lui, son message d'erreur serait publié APRÈS qu'apiCall a résolu.
+        await onError(err);
+      } else if (err.response?.status === 422) {
+        errors.value.validationErrors = err.response.data.errors;
+      } else {
+        errors.value[operation] = err.response?.data?.message || "Une erreur est survenue.";
+        notify('error', errors.value[operation]);
+      }
+
+      if (relancerLesErreurs) throw err;
+    } finally {
+      setLoading(operation, false);
+    }
+  }
+
+  return { apiCall, clearErrors, setLoading };
+}
+```
+
+> Note : `clearErrors` ne vide **pas** `errors.validationErrors` — c'est une dette
+> connue, figée par un test. Ne la « corrige » pas ici.
+
+- [ ] **Step 2: Migrer le store clients**
+
+Dans `resources/js/stores/clients.js` :
+
+1. Ajouter l'import : `import { creerApiCall } from '@/stores/apiCall';`
+2. **Supprimer** les trois fonctions `clearErrors`, `setLoading` et `apiCall` (elles se suivent, juste après les `ref`).
+3. Les remplacer, immédiatement après `const loading = ref({});`, par :
+
+```js
+  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
+```
+
+4. Vérifier que l'import `notify` de `@/utils` est **toujours utilisé** ailleurs dans le fichier (les `onSuccess` l'appellent pour les toasts de succès). S'il ne l'est plus, le retirer ; s'il l'est, le garder.
+
+- [ ] **Step 3: Lancer les tests**
+
+Run: `npm run test`
+Expected: PASS — **52 tests**, dont les 7 de `clients.test.js`, **sans qu'un seul test ait été modifié**.
+
+C'est le résultat qui compte : la fabrique reproduit exactement le comportement du store de référence. Si un test de `clients` casse, **la fabrique est fausse** — corrige-la, ne touche pas au test.
+
+- [ ] **Step 4: Vérifier que la fabrique sert vraiment**
+
+Preuve de bonne foi. Casse temporairement la fabrique : dans `apiCall.js`, remplace `setLoading(operation, true);` par rien (supprime la ligne).
+
+Run: `npm run test`
+Expected: **ÉCHEC** — le test « monte le chargement a true PENDANT la requete » rougit. C'est la preuve que le filet couvre le code que tu viens d'extraire.
+
+Puis **restaure la ligne** et relance : 52 tests verts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/stores/apiCall.js resources/js/stores/clients.js
+git commit -m "refactor: extrait apiCall en fabrique partagee, migre le store clients"
+```
+
+---
+
+### Task 2 : Les deux autres stores conformes
+
+`taux-horaires` et `prestations` ont un `apiCall` **identique caractère pour caractère** à celui de `clients`. Leur migration est mécanique, et leurs tests doivent rester verts sans modification.
+
+**Files:**
+- Modify: `resources/js/stores/taux-horaires.js`
+- Modify: `resources/js/stores/prestations.js`
+
+**Interfaces:**
+- Consumes: `creerApiCall({ errors, loading })` (tâche 1).
+- Produces: rien.
+
+- [ ] **Step 1: Migrer taux-horaires**
+
+Dans `resources/js/stores/taux-horaires.js` :
+
+1. Ajouter `import { creerApiCall } from '@/stores/apiCall';`
+2. Supprimer les fonctions `clearErrors`, `setLoading` et `apiCall`.
+3. Les remplacer, juste après `const loading = ref({});`, par :
+
+```js
+  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
+```
+
+4. Vérifier si l'import `notify` est toujours utilisé dans le fichier (les toasts de succès des `onSuccess`). Le retirer seulement s'il ne l'est plus.
+
+- [ ] **Step 2: Migrer prestations**
+
+Même opération dans `resources/js/stores/prestations.js`.
+
+Attention : ce store a de la logique métier autour (`activeFilters`, `filteredPrestations`, `unbilledPrestations`, un `watch`). **N'y touche pas.** Tu ne remplaces que les trois fonctions.
+
+- [ ] **Step 3: Lancer les tests**
+
+Run: `npm run test`
+Expected: PASS — 52 tests, **aucun test modifié**. Si un test de `taux-horaires` ou de `prestations` casse, c'est une régression : reprends le code.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/stores/taux-horaires.js resources/js/stores/prestations.js
+git commit -m "refactor: migre les stores taux-horaires et prestations vers la fabrique"
+```
+
+---
+
+### Task 3 : Le store auth, qui relance ses erreurs
+
+**Files:**
+- Modify: `resources/js/stores/auth.js`
+
+**Interfaces:**
+- Consumes: `creerApiCall({ errors, loading, relancerLesErreurs })` (tâche 1).
+- Produces: rien.
+
+Ce store a une particularité : son `catch` se termine par `throw err;`. Il **relance** l'erreur après l'avoir traitée.
+
+**Le piège, que les tests ont désamorcé :** ce `throw` **ne sert pas à `login`**. Contrairement à ce qu'on pourrait croire, `login()` n'utilise **pas** `apiCall` — c'est du code écrit à la main, avec son propre `try/catch`, son message d'erreur en dur et un toast importé directement. **Seul `updateUser()` passe par `apiCall`** dans ce store, et c'est lui, et lui seul, que le `throw` sert.
+
+**Ne touche pas à `login()` ni à `logout()`.** Tu ne remplaces que les trois fonctions.
+
+- [ ] **Step 1: Migrer auth**
+
+Dans `resources/js/stores/auth.js` :
+
+1. Ajouter `import { creerApiCall } from '@/stores/apiCall';`
+2. Supprimer les fonctions `clearErrors`, `setLoading` et `apiCall`.
+3. Les remplacer, juste après la déclaration de `loading`, par :
+
+```js
+  // relancerLesErreurs : ce store relance l'erreur après l'avoir traitée.
+  // C'est updateUser() — la seule opération de ce store qui passe par apiCall —
+  // qui en dépend. login() a son propre try/catch et ne passe pas par ici.
+  const { apiCall, clearErrors, setLoading } = creerApiCall({
+    errors,
+    loading,
+    relancerLesErreurs: true,
+  });
+```
+
+4. Vérifier si l'import `notify` est toujours utilisé. Attention : ce store importe aussi `useToast` de `vue-toastification` **directement** (pour `login`) — ne le retire pas.
+
+- [ ] **Step 2: Lancer les tests**
+
+Run: `npm run test`
+Expected: PASS — 52 tests, **aucun test modifié**.
+
+Deux tests méritent ton attention ; ils doivent **rester verts** :
+- celui qui prouve qu'`updateUser` **relance** l'erreur (si tu as oublié `relancerLesErreurs: true`, il rougira) ;
+- celui qui fige le bug connu : **`updateUser` ne met jamais à jour `store.user`** (le paramètre masque la ref). **Ne corrige pas ce bug** — s'il devient vert autrement, c'est que tu as changé un comportement sans le décider.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/stores/auth.js
+git commit -m "refactor: migre le store auth vers la fabrique (avec relance des erreurs)"
+```
+
+---
+
+### Task 4 : Le store des factures — la divergence
+
+C'est ici, et **seulement ici**, que des tests ont le droit de casser.
+
+**Files:**
+- Modify: `resources/js/stores/factures.js`
+- Modify: `resources/js/stores/factures.test.js`
+
+**Interfaces:**
+- Consumes: `creerApiCall({ errors, loading })` (tâche 1).
+- Produces: rien (dernière tâche).
+
+Son `apiCall` faisait `return onSuccess ? onSuccess(response) : response;` — il retournait ce que retournait `onSuccess`. En s'alignant sur la fabrique, il retourne désormais **la réponse**. Trois conséquences, toutes assumées :
+
+1. **`addInvoice`** avait un `return true;` explicite à la fin de son `onSuccess` — un pansement ajouté parce que, sans lui, l'appelant recevait `undefined` et ne pouvait pas distinguer un succès d'un échec. **Ce pansement devient inutile : retire-le.** `FactureFormModal` fait `if (succes) close()` : la réponse axios étant *truthy*, il continue de fonctionner.
+2. **`getInvoicePdf`** construisait l'URL de son blob **dans** `onSuccess` et comptait sur le retour d'`apiCall` pour la récupérer. Il doit désormais la construire **après** l'appel.
+3. **`fetchInvoices`** retournait `undefined` (son `onSuccess` ne retourne rien). Il retournera la réponse. Aucun appelant n'en dépend.
+
+- [ ] **Step 1: Migrer le store**
+
+Dans `resources/js/stores/factures.js` :
+
+1. Ajouter `import { creerApiCall } from '@/stores/apiCall';`
+2. Supprimer `clearErrors`, `setLoading` et `apiCall`, et les remplacer, juste après `const loading = ref({});`, par :
+
+```js
+  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
+```
+
+3. Dans `addInvoice`, **supprimer le `return true;`** à la fin de son `onSuccess` (ainsi que le commentaire qui l'accompagne : il expliquait un pansement qui n'a plus lieu d'être).
+
+4. Récrire `getInvoicePdf` pour qu'il construise l'URL **après** l'appel. Le `onSuccess` disparaît (c'est lui qui construisait l'URL) ; le `onError` est repris **à l'identique**, ses `return "";` en moins — devenus inutiles puisque c'est `getInvoicePdf` qui retourne `""` en cas d'échec :
+
+```js
+  async function getInvoicePdf(invoiceId) {
+    const response = await apiCall({
+      operation: "pdf",
+      request: () => axios.get(`/api/factures/${invoiceId}/pdf`, { responseType: "blob" }),
+      onError: async (err) => {
+        // 1) Erreurs réseau (aucune réponse HTTP)
+        if (!err.response) {
+          const msg =
+            err.code === "ECONNABORTED"
+              ? "Délai d’attente dépassé. Vérifiez votre connexion et réessayez."
+              : "Impossible de contacter le serveur. Vérifiez votre connexion Internet.";
+
+          errors.value.pdf = msg;   // modale
+          notify("error", msg);     // toast
+          return;
+        }
+
+        const status = err.response.status;
+        const contentType = (err.response.headers?.["content-type"] || "").toLowerCase();
+
+        // Helper: extraire un message JSON même si responseType=blob
+        const readJsonMessage = async () => {
+          if (!contentType.includes("application/json")) return null;
+
+          const text = await err.response.data.text();
+          try {
+            const payload = JSON.parse(text);
+            return payload?.message || null;
+          } catch {
+            return null;
+          }
+        };
+
+        // 2) Erreur métier "profil incomplet" (ou autre validation)
+        if (status === 422 || status === 403) {
+          const msg =
+            (await readJsonMessage()) ||
+            "Votre profil est incomplet. Complétez vos informations dans les paramètres.";
+
+          errors.value.pdf = msg;   // modale
+          notify("error", msg);     // toast
+          return;
+        }
+
+        // 3) Autres erreurs HTTP (serveur, permissions, etc.)
+        const msg =
+          (await readJsonMessage()) ||
+          "Erreur technique lors de la génération du PDF. Réessayez dans quelques instants.";
+
+        errors.value.pdf = msg;     // modale
+        notify("error", msg);       // toast
+      },
+    });
+
+    // L'URL est construite APRÈS l'appel : apiCall retourne désormais la réponse,
+    // et non plus ce que retourne onSuccess.
+    if (!response) return "";
+
+    return URL.createObjectURL(new Blob([response.data], { type: "application/pdf" }));
+  }
+```
+
+**Ne reformule pas cette gestion d'erreur, ne la simplifie pas** : elle distingue l'erreur réseau, le profil incomplet (422/403) et l'erreur technique, et sait lire un message JSON dans une réponse en `blob`. Ce n'est pas l'objet de ce refactor.
+
+- [ ] **Step 2: Lancer les tests et CONSTATER les échecs attendus**
+
+Run: `npm run test`
+Expected: **ÉCHEC** — et c'est le résultat voulu. Les tests qui doivent rougir sont ceux de `factures.test.js` qui décrivent la divergence :
+- « DIVERGENCE : apiCall retourne le resultat de onSuccess, pas la reponse » ;
+- ceux qui attendent `true` d'`addInvoice`.
+
+**Vérifie que SEULS ces tests-là cassent.** Si un test d'un autre store rougit, ou si un test de `factures` sans rapport avec la divergence rougit, c'est une **régression** : reprends le code, pas le test.
+
+- [ ] **Step 3: Mettre à jour les tests de la divergence**
+
+Dans `resources/js/stores/factures.test.js`, récris les tests concernés pour qu'ils décrivent le **nouveau** comportement — désormais aligné sur les quatre autres stores :
+
+- `apiCall` retourne **la réponse** (et non le résultat de `onSuccess`) ;
+- `addInvoice` retourne donc la réponse, qui est *truthy* — ce qui suffit à `FactureFormModal` pour décider de fermer sa modale ;
+- `addInvoice` retourne toujours une valeur *falsy* en cas d'échec (ce test-là ne change pas : c'est ce qui empêche la modale de se fermer sur un échec).
+
+Renomme les tests : « DIVERGENCE » n'a plus lieu d'être, puisqu'elle a disparu. Le commentaire du test peut rappeler ce qu'elle était et le bug qu'elle a causé — c'est une trace utile.
+
+- [ ] **Step 4: Lancer les tests**
+
+Run: `npm run test`
+Expected: PASS — 52 tests.
+
+- [ ] **Step 5: Vérifier que la duplication a bien disparu**
+
+Run: `grep -c "async function apiCall" resources/js/stores/*.js`
+Expected: `apiCall.js:1` et **0 pour tous les autres**. Plus aucune copie.
+
+Run: `git diff main --stat -- resources/js/stores/`
+Expected: un solde **négatif** d'environ 110 lignes sur les stores (hors fichiers de test).
+
+- [ ] **Step 6: Vérifier le backend et le build**
+
+Run: `php artisan test`
+Expected: PASS — 90 tests. Rien ici ne touche au backend ; un échec signalerait une erreur.
+
+Run: `npm run build`
+Expected: build Vite réussi.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add resources/js/stores/factures.js resources/js/stores/factures.test.js
+git commit -m "refactor: aligne le store des factures sur la fabrique partagee"
+```
+
+---
+
+## Vérification finale
+
+- [ ] `npm run test` — 52 tests verts.
+- [ ] `php artisan test` — 90 tests verts.
+- [ ] `npm run build` — passe.
+- [ ] **Seuls les tests de `factures.test.js` décrivant la divergence ont été modifiés.** Vérifier avec `git diff main --name-only -- 'resources/js/stores/*.test.js'` : seul `factures.test.js` doit apparaître. Si un autre fichier de test a été touché, c'est qu'on a maquillé une régression.
+- [ ] **Les deux dettes sont toujours figées** : le test qui atteste que `updateUser` ne met pas à jour `store.user`, et celui qui atteste que `errors.validationErrors` n'est jamais vidé, sont **toujours verts et inchangés**.
+- [ ] Contrôle manuel dans l'application : se connecter, créer un client, créer une facture, **afficher un PDF** (le seul chemin dont le code change réellement), marquer une facture payée.

--- a/docs/superpowers/specs/2026-07-13-apicall-partage-design.md
+++ b/docs/superpowers/specs/2026-07-13-apicall-partage-design.md
@@ -1,0 +1,133 @@
+# Extraire `apiCall` : une seule source de vérité pour les appels API
+
+Date : 2026-07-13
+
+## Problème
+
+`apiCall` — la fonction qui enveloppe chaque appel API d'un store (chargement,
+erreurs, notifications) — est **copiée dans cinq stores**, avec ses compagnes
+`clearErrors` et `setLoading` : environ 28 lignes dupliquées cinq fois.
+
+Trois de ces copies (`clients`, `taux-horaires`, `prestations`) sont **identiques
+caractère pour caractère**. Une a **divergé** : `factures`.
+
+```js
+// Le comportement de référence (4 stores)
+if (onSuccess) onSuccess(response);
+return response;
+
+// factures
+return onSuccess ? onSuccess(response) : response;
+```
+
+**Cette divergence a produit un bug réel.** `addInvoice` retournait ce que
+retournait *son* `onSuccess` — c'est-à-dire `undefined`, faute de `return`. La
+modale de création de facture ne pouvait donc pas distinguer un succès d'un échec :
+elle se fermait dans les deux cas, effaçant la sélection de l'utilisateur (jusqu'à
+25 prestations à recocher). Le correctif d'alors — ajouter un `return true`
+explicite dans `onSuccess` — était un pansement sur le symptôme.
+
+**La duplication est la cause.** Quatre copies d'une même fonction, dont une a
+dérivé sans que rien ne le signale. Sans extraction, la prochaine divergence est
+une question de temps.
+
+## Décisions
+
+**Extraire une fabrique partagée**, plutôt que d'aligner seulement le mouton noir.
+Aligner `factures` corrigerait ce symptôme-ci et laisserait la cause intacte.
+
+**Le comportement de référence est celui des quatre stores conformes.** C'est
+`factures` qui s'aligne, pas l'inverse.
+
+**Le filet existe déjà.** 52 tests de caractérisation (PR #29) décrivent le
+comportement actuel de chaque store, divergences comprises. Ils sont le juge de ce
+refactor : ce qui reste vert n'a pas bougé ; ce qui casse est exactement ce qu'on a
+changé.
+
+## Conception
+
+### La fabrique
+
+`resources/js/stores/apiCall.js` exporte `creerApiCall({ errors, loading, relancerLesErreurs })`,
+qui retourne `{ apiCall, clearErrors, setLoading }`. Chaque store lui passe ses
+propres refs `errors` et `loading`.
+
+Elle porte le comportement des quatre stores conformes, et absorbe les **deux
+besoins réels** qui existent aujourd'hui :
+
+- **`onError`** (paramètre optionnel de `apiCall`) : `getInvoicePdf` en a besoin
+  pour extraire un message d'erreur d'une réponse en `blob`. Les autres stores ne
+  le passent pas — rien ne change pour eux.
+- **`relancerLesErreurs`** (option de la fabrique) : seul `auth` l'active, pour
+  conserver le `throw err` de son `catch`.
+
+### Le piège que les tests ont désamorcé
+
+Le `throw` d'`auth` **ne concerne pas `login`**. Contrairement à ce que supposait la
+conception initiale, `login()` n'utilise **pas** `apiCall` : c'est du code écrit à
+la main, qui ne relance rien, code son message d'erreur en dur et notifie via un
+toast importé directement. **Seul `updateUser()` passe par `apiCall`** dans ce
+store — et c'est lui, et lui seul, que le `throw` sert.
+
+Supprimer l'option en croyant `login` concerné aurait cassé silencieusement le seul
+appelant qui en dépend. Les tests de caractérisation ont corrigé cette erreur avant
+qu'elle ne soit commise.
+
+### Les changements de comportement — tous dans `factures.js`
+
+Ce sont les seuls, et ils sont assumés :
+
+1. **`apiCall` retourne la réponse.** Conséquences : `addInvoice` n'a plus besoin du
+   `return true` ajouté en pansement (il est retiré), et `fetchInvoices` cesse de
+   retourner `undefined`.
+2. **`getInvoicePdf` construit l'URL de son blob après l'appel**, et non plus dans
+   `onSuccess`.
+3. **`onError` est attendu (`await`).** Aujourd'hui il ne l'est pas : son message
+   d'erreur est publié par une promesse flottante, après qu'`apiCall` a déjà résolu.
+   Le test actuel survit à trois microtâches et casse à cinq — il passe, mais il est
+   ancré sur une course.
+
+`FactureFormModal` fait `if (succes) close()`. La réponse axios étant *truthy*, ce
+code continue de fonctionner sans modification.
+
+### Ce qu'on ne corrige surtout pas
+
+Deux dettes réelles ont été **figées** par les tests de caractérisation :
+
+- `auth.updateUser()` ne met **jamais** à jour `store.user` : le paramètre `user`
+  masque la ref du store, et le `.value` est posé sur l'argument.
+- `errors.validationErrors` n'est **jamais vidé** : `clearErrors(operation)` ne
+  remet à `null` que `errors[operation]`.
+
+**Leurs tests doivent rester verts.** Les corriger ici mélangerait deux
+changements : un refactor (aucun changement de comportement) et des corrections de
+bugs. Si le refactor les fait casser, c'est qu'un comportement a changé sans qu'on
+l'ait décidé — et le filet aura fait son travail.
+
+`dashboard.js` reste à l'écart : il n'a pas d'`apiCall` et gère son chargement à la
+main. L'y intégrer serait une refonte sans rapport.
+
+## Tests
+
+**Le filet existe : 52 tests (PR #29).** Aucun nouveau test n'est à écrire pour le
+refactor lui-même — c'est tout l'intérêt de les avoir écrits avant.
+
+**Les seuls tests autorisés à casser** sont ceux qui décrivent les divergences de
+`factures` (`resources/js/stores/factures.test.js`) :
+
+- « DIVERGENCE : apiCall retourne le resultat de onSuccess, pas la reponse » → devra
+  être récrit pour constater que la réponse est retournée.
+- Les tests dépendant du `return true` d'`addInvoice`.
+
+Tout autre test rouge est une **régression** : le corriger en modifiant le test
+serait une faute — c'est le code qu'il faut reprendre.
+
+Vérification finale : `npm run test` vert, `php artisan test` vert (90), et le
+décompte des lignes supprimées (~110) confirme que la duplication a bien disparu.
+
+## Hors périmètre
+
+- Corriger le shadowing de `user` dans `updateUser`.
+- Vider `errors.validationErrors` dans `clearErrors`.
+- `dashboard.js`.
+- `auth.login()`, qui n'utilise pas `apiCall`.

--- a/resources/js/stores/apiCall.js
+++ b/resources/js/stores/apiCall.js
@@ -1,0 +1,67 @@
+import { notify } from '@/utils';
+
+/**
+ * Fabrique l'enveloppe des appels API d'un store : chargement, erreurs,
+ * notifications.
+ *
+ * Cette fonction était copiée dans cinq stores. Trois copies étaient identiques
+ * caractère pour caractère, une avait divergé — et cette divergence a produit un
+ * bug réel (une modale qui se fermait sur un échec, effaçant la saisie).
+ *
+ * @param {object} refs
+ * @param {import('vue').Ref<object>} refs.errors   Les erreurs du store, par opération.
+ * @param {import('vue').Ref<object>} refs.loading  Les états de chargement, par opération.
+ * @param {boolean} [refs.relancerLesErreurs=false] Relance l'erreur après l'avoir
+ *   traitée. Seul le store `auth` l'active : son `updateUser()` compte dessus.
+ */
+export function creerApiCall({ errors, loading, relancerLesErreurs = false }) {
+  function clearErrors(operation) {
+    if (operation) {
+      errors.value[operation] = null;
+    } else {
+      errors.value = {};
+    }
+  }
+
+  function setLoading(operation, state) {
+    loading.value[operation] = state;
+  }
+
+  /**
+   * @param {object} options
+   * @param {string} options.operation   Clé sous laquelle chargement et erreur sont rangés.
+   * @param {Function} options.request   L'appel axios.
+   * @param {Function} [options.onSuccess] Effets de bord au succès. Sa valeur de
+   *   retour est IGNORÉE : apiCall retourne toujours la réponse.
+   * @param {Function} [options.onError]   Gestion d'erreur sur mesure, qui remplace
+   *   le traitement par défaut. Seul `getInvoicePdf` en a besoin (réponse en blob).
+   * @returns {Promise<*>} La réponse au succès, `undefined` en cas d'échec.
+   */
+  async function apiCall({ operation, request, onSuccess, onError }) {
+    clearErrors(operation);
+    setLoading(operation, true);
+
+    try {
+      const response = await request();
+      if (onSuccess) onSuccess(response);
+      return response;
+    } catch (err) {
+      if (onError) {
+        // `await` : onError peut être asynchrone (getInvoicePdf lit un blob).
+        // Sans lui, son message d'erreur serait publié APRÈS qu'apiCall a résolu.
+        await onError(err);
+      } else if (err.response?.status === 422) {
+        errors.value.validationErrors = err.response.data.errors;
+      } else {
+        errors.value[operation] = err.response?.data?.message || "Une erreur est survenue.";
+        notify('error', errors.value[operation]);
+      }
+
+      if (relancerLesErreurs) throw err;
+    } finally {
+      setLoading(operation, false);
+    }
+  }
+
+  return { apiCall, clearErrors, setLoading };
+}

--- a/resources/js/stores/auth.js
+++ b/resources/js/stores/auth.js
@@ -16,7 +16,7 @@ export const useAuthStore = defineStore("auth", () => {
   // relancerLesErreurs : ce store relance l'erreur après l'avoir traitée.
   // C'est updateUser() — la seule opération de ce store qui passe par apiCall —
   // qui en dépend. login() a son propre try/catch et ne passe pas par ici.
-  const { apiCall, clearErrors, setLoading } = creerApiCall({
+  const { apiCall, clearErrors } = creerApiCall({
     errors,
     loading,
     relancerLesErreurs: true,

--- a/resources/js/stores/auth.js
+++ b/resources/js/stores/auth.js
@@ -4,6 +4,7 @@ import { useRouter } from "vue-router";
 import axios from "axios";
 import { useToast } from "vue-toastification";
 import { notify } from "@/utils";
+import { creerApiCall } from "@/stores/apiCall";
 
 export const useAuthStore = defineStore("auth", () => {
   const user = ref(null);
@@ -11,6 +12,15 @@ export const useAuthStore = defineStore("auth", () => {
   const loading = ref({});
   const router = useRouter();
   const toast = useToast();
+
+  // relancerLesErreurs : ce store relance l'erreur après l'avoir traitée.
+  // C'est updateUser() — la seule opération de ce store qui passe par apiCall —
+  // qui en dépend. login() a son propre try/catch et ne passe pas par ici.
+  const { apiCall, clearErrors, setLoading } = creerApiCall({
+    errors,
+    loading,
+    relancerLesErreurs: true,
+  });
 
   const isAuthenticated = computed(() => !!user.value);
 
@@ -53,38 +63,6 @@ export const useAuthStore = defineStore("auth", () => {
     user.value = null;
     toast.info("Déconnexion réussie.");
     await router.push("/login");
-  }
-
-  function clearErrors(operation) {
-    if (operation) {
-      errors.value[operation] = null;
-    } else {
-      errors.value = {};
-    }
-  }
-
-  function setLoading(operation, state) {
-    loading.value[operation] = state;
-  }
-
-  async function apiCall({ operation, request, onSuccess }) {
-      clearErrors(operation);
-      setLoading(operation, true);
-      try {
-        const response = await request();
-        if (onSuccess) onSuccess(response);
-        return response;
-      } catch (err) {
-        if (err.response?.status === 422) {
-          errors.value.validationErrors = err.response.data.errors;
-        } else {
-          errors.value[operation] = err.response?.data?.message || "Une erreur est survenue.";
-          notify('error', errors.value[operation]);
-        }
-        throw err;
-      } finally {
-        setLoading(operation, false);
-      }
   }
 
   async function updateUser(user) {

--- a/resources/js/stores/clients.js
+++ b/resources/js/stores/clients.js
@@ -48,7 +48,7 @@ export const useClientsStore = defineStore('clients', () => {
   });
   */
 
-  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
+  const { apiCall, clearErrors } = creerApiCall({ errors, loading });
 
   async function fetchClients() {
     return apiCall({

--- a/resources/js/stores/clients.js
+++ b/resources/js/stores/clients.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { notify } from '@/utils';
 import { useStorage } from '@vueuse/core';
 import dayjs from 'dayjs';
+import { creerApiCall } from '@/stores/apiCall';
 
 export const useClientsStore = defineStore('clients', () => {
   const clients = ref([]);
@@ -47,36 +48,7 @@ export const useClientsStore = defineStore('clients', () => {
   });
   */
 
-  function clearErrors(operation) {
-    if (operation) {
-      errors.value[operation] = null;
-    } else {
-      errors.value = {};
-    }
-  }
-
-  function setLoading(operation, state) {
-    loading.value[operation] = state;
-  }
-
-  async function apiCall({ operation, request, onSuccess }) {
-    clearErrors(operation);
-    setLoading(operation, true);
-    try {
-      const response = await request();
-      if (onSuccess) onSuccess(response);
-      return response;
-    } catch (err) {
-      if (err.response?.status === 422) {
-        errors.value.validationErrors = err.response.data.errors;
-      } else {
-        errors.value[operation] = err.response?.data?.message || "Une erreur est survenue.";
-        notify('error', errors.value[operation]);
-      }
-    } finally {
-      setLoading(operation, false);
-    }
-  }
+  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
 
   async function fetchClients() {
     return apiCall({

--- a/resources/js/stores/factures.js
+++ b/resources/js/stores/factures.js
@@ -4,6 +4,7 @@ import { ref, computed, watch } from 'vue';
 import axios from 'axios';
 import { notify } from '@/utils';
 import { useDashboardStore } from "@/stores/dashboard";
+import { creerApiCall } from '@/stores/apiCall';
 
 
 export const useInvoicesStore = defineStore('invoices', () => {
@@ -50,37 +51,7 @@ export const useInvoicesStore = defineStore('invoices', () => {
 
   const dashboardStore = useDashboardStore();
 
-  function clearErrors(operation) {
-    if (operation) {
-      errors.value[operation] = null;
-    } else {
-      errors.value = {};
-    }
-  }
-
-  function setLoading(operation, state) {
-    loading.value[operation] = state;
-  }
-
-  async function apiCall({ operation, request, onSuccess, onError }) {
-    clearErrors(operation);
-    setLoading(operation, true);
-    try {
-      const response = await request();
-      return onSuccess ? onSuccess(response) : response;
-    } catch (err) {
-      if (onError) {
-        onError(err);
-      } else if (err.response?.status === 422) {
-        errors.value.validationErrors = err.response.data.errors;
-      } else {
-        errors.value[operation] = err.response?.data?.message || "Une erreur est survenue.";
-        notify('error', errors.value[operation]);
-      }
-    } finally {
-      setLoading(operation, false);
-    }
-  }
+  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
 
   async function fetchInvoices() {
     return apiCall({
@@ -104,11 +75,6 @@ export const useInvoicesStore = defineStore('invoices', () => {
         }
 
         notify('success', response.data.message);
-
-        // Signale explicitement le succès : apiCall renvoie ce que retourne
-        // onSuccess. Sans ce `true`, l'appelant reçoit `undefined` et ne peut
-        // pas distinguer une création réussie d'un échec.
-        return true;
       },
     });
   }
@@ -126,63 +92,64 @@ export const useInvoicesStore = defineStore('invoices', () => {
 
   // Récupère et affiche le PDF d'une facture
   async function getInvoicePdf(invoiceId) {
-    return apiCall({
+    const response = await apiCall({
       operation: "pdf",
       request: () => axios.get(`/api/factures/${invoiceId}/pdf`, { responseType: "blob" }),
-      onSuccess: (response) => {
-        return URL.createObjectURL(new Blob([response.data], { type: "application/pdf" }));
-      },
       onError: async (err) => {
-      // 1) Erreurs réseau (aucune réponse HTTP)
-      if (!err.response) {
-        const msg =
-          err.code === "ECONNABORTED"
-            ? "Délai d’attente dépassé. Vérifiez votre connexion et réessayez."
-            : "Impossible de contacter le serveur. Vérifiez votre connexion Internet.";
+        // 1) Erreurs réseau (aucune réponse HTTP)
+        if (!err.response) {
+          const msg =
+            err.code === "ECONNABORTED"
+              ? "Délai d’attente dépassé. Vérifiez votre connexion et réessayez."
+              : "Impossible de contacter le serveur. Vérifiez votre connexion Internet.";
 
-        errors.value.pdf = msg;   // modale
-        notify("error", msg);     // toast
-        return "";
-      }
-
-      const status = err.response.status;
-      const contentType = (err.response.headers?.["content-type"] || "").toLowerCase();
-
-      // Helper: extraire un message JSON même si responseType=blob
-      const readJsonMessage = async () => {
-        if (!contentType.includes("application/json")) return null;
-
-        const text = await err.response.data.text();
-        try {
-          const payload = JSON.parse(text);
-          return payload?.message || null;
-        } catch {
-          return null;
+          errors.value.pdf = msg;   // modale
+          notify("error", msg);     // toast
+          return;
         }
-      };
 
-      // 2) Erreur métier "profil incomplet" (ou autre validation)
-      // Si vous ne voulez viser QUE le profil incomplet, vous pouvez aussi matcher sur le texte.
-      if (status === 422 || status === 403) {
+        const status = err.response.status;
+        const contentType = (err.response.headers?.["content-type"] || "").toLowerCase();
+
+        // Helper: extraire un message JSON même si responseType=blob
+        const readJsonMessage = async () => {
+          if (!contentType.includes("application/json")) return null;
+
+          const text = await err.response.data.text();
+          try {
+            const payload = JSON.parse(text);
+            return payload?.message || null;
+          } catch {
+            return null;
+          }
+        };
+
+        // 2) Erreur métier "profil incomplet" (ou autre validation)
+        if (status === 422 || status === 403) {
+          const msg =
+            (await readJsonMessage()) ||
+            "Votre profil est incomplet. Complétez vos informations dans les paramètres.";
+
+          errors.value.pdf = msg;   // modale
+          notify("error", msg);     // toast
+          return;
+        }
+
+        // 3) Autres erreurs HTTP (serveur, permissions, etc.)
         const msg =
           (await readJsonMessage()) ||
-          "Votre profil est incomplet. Complétez vos informations dans les paramètres.";
+          "Erreur technique lors de la génération du PDF. Réessayez dans quelques instants.";
 
-        errors.value.pdf = msg;   // modale
-        notify("error", msg);     // toast
-        return "";
-      }
-
-      // 3) Autres erreurs HTTP (serveur, permissions, etc.)
-      const msg =
-        (await readJsonMessage()) ||
-        "Erreur technique lors de la génération du PDF. Réessayez dans quelques instants.";
-
-      errors.value.pdf = msg;     // modale
-      notify("error", msg);       // toast
-      return "";
-    },
+        errors.value.pdf = msg;     // modale
+        notify("error", msg);       // toast
+      },
     });
+
+    // L'URL est construite APRÈS l'appel : apiCall retourne désormais la réponse,
+    // et non plus ce que retourne onSuccess.
+    if (!response) return "";
+
+    return URL.createObjectURL(new Blob([response.data], { type: "application/pdf" }));
   }
 
   async function paid(invoiceId) {

--- a/resources/js/stores/factures.js
+++ b/resources/js/stores/factures.js
@@ -51,7 +51,7 @@ export const useInvoicesStore = defineStore('invoices', () => {
 
   const dashboardStore = useDashboardStore();
 
-  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
+  const { apiCall, clearErrors } = creerApiCall({ errors, loading });
 
   async function fetchInvoices() {
     return apiCall({

--- a/resources/js/stores/factures.test.js
+++ b/resources/js/stores/factures.test.js
@@ -180,4 +180,23 @@ describe('store factures — apiCall (alignee sur la fabrique partagee)', () => 
     expect(store.errors.validationErrors).toBeUndefined();
     expect(notify).toHaveBeenCalledWith('error', store.errors.pdf);
   });
+
+  it('onError est attendu : errors.pdf est pose AVANT que getInvoicePdf resolve', async () => {
+    // Un vrai Blob.text() ne resout pas en une microtache. Sans `await onError`,
+    // apiCall resout avant qu'onError ait lu le blob : la modale s'affiche vide
+    // (ni message, ni spinner), puis l'erreur surgit apres coup.
+    axios.get.mockRejectedValue({
+      response: {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+        data: { text: () => new Promise((r) =>
+          setTimeout(() => r(JSON.stringify({ message: 'Profil incomplet.' })), 0)) },
+      },
+    });
+    const store = useInvoicesStore();
+
+    await store.getInvoicePdf(1);
+
+    expect(store.errors.pdf).toBe('Profil incomplet.');
+  });
 });

--- a/resources/js/stores/factures.test.js
+++ b/resources/js/stores/factures.test.js
@@ -24,23 +24,24 @@ function erreurAxios(status, data = {}) {
 // factures.js importe useDashboardStore : setActivePinia(createPinia()) suffit
 // a le faire s'instancier normalement, pas besoin de le mocker.
 
-describe('store factures — apiCall (la divergence)', () => {
+describe('store factures — apiCall (alignee sur la fabrique partagee)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
   });
 
-  it('fetchInvoices retourne la reponse au succes (comportement standard, comme onSuccess ne retourne rien)', async () => {
+  it('fetchInvoices retourne la reponse axios (alignee sur la fabrique, la valeur de retour de onSuccess est ignoree)', async () => {
+    // Avant l'alignement, apiCall(factures) faisait
+    // `return onSuccess ? onSuccess(response) : response;`. Comme le onSuccess
+    // de fetchInvoices ne retournait rien, le resultat etait `undefined`, pas
+    // la réponse axios — une trace de la divergence. Desormais apiCall
+    // retourne toujours la réponse, comme dans les quatre autres stores.
     axios.get.mockResolvedValue({ data: { factures: [{ id: 1 }] } });
     const store = useInvoicesStore();
 
     const resultat = await store.fetchInvoices();
 
-    // fetchInvoices : onSuccess ne retourne rien (undefined), donc apiCall
-    // renvoie `onSuccess(response)` = undefined, PAS la réponse axios.
-    // C'est déjà une trace de la divergence : seule addInvoice s'en sort
-    // grâce à son `return true` explicite.
-    expect(resultat).toBeUndefined();
+    expect(resultat).toEqual({ data: { factures: [{ id: 1 }] } });
     expect(store.invoices).toHaveLength(1);
   });
 
@@ -85,18 +86,21 @@ describe('store factures — apiCall (la divergence)', () => {
     expect(resultat).toBeFalsy();
   });
 
-  it('DIVERGENCE : apiCall retourne le resultat de onSuccess, pas la reponse', async () => {
-    // Les quatre autres stores font `if (onSuccess) onSuccess(response); return response;`
-    // Celui-ci fait `return onSuccess ? onSuccess(response) : response;`
-    // addInvoice retourne donc ce que retourne SON onSuccess — un `true` explicite,
-    // ajouté précisément parce que sans lui l'appelant recevait `undefined` et ne
-    // pouvait pas distinguer un succès d'un échec.
+  it('apiCall retourne la reponse (alignee sur la fabrique) : addInvoice n\'a plus besoin d\'un `return true` explicite', async () => {
+    // Avant : apiCall(factures) faisait `return onSuccess ? onSuccess(response) : response;`.
+    // addInvoice retournait donc ce que retournait SON onSuccess — d'où un `return true`
+    // explicite ajouté en pansement, sans lequel l'appelant recevait `undefined` et
+    // FactureFormModal ne pouvait pas distinguer un succès d'un échec : elle se
+    // fermait dans les deux cas, effaçant la sélection de prestations de l'utilisateur.
+    // Désormais apiCall retourne toujours la réponse — truthy au succès — ce qui
+    // suffit à `if (succes) close()`.
     axios.post.mockResolvedValue({ data: { facture: { id: 1 }, message: 'Créée' } });
     const store = useInvoicesStore();
 
     const resultat = await store.addInvoice({ prestations: [1] });
 
-    expect(resultat).toBe(true); // et NON la réponse axios
+    expect(resultat).toEqual({ data: { facture: { id: 1 }, message: 'Créée' } });
+    expect(resultat).toBeTruthy();
   });
 
   it('addInvoice retourne une valeur falsy en cas d\'echec', async () => {
@@ -163,15 +167,14 @@ describe('store factures — apiCall (la divergence)', () => {
     });
     const store = useInvoicesStore();
 
-    // Autre bizarrerie propre a apiCall(factures) : dans le catch, `onError(err)`
-    // est appelé SANS await. Le message d'erreur qu'il calcule (via un `await`
-    // interne) finit bien dans errors.pdf/notify, mais la valeur de retour de
-    // ce onError ('') n'est elle-même jamais renvoyée par apiCall : le catch ne
-    // fait rien de son résultat. getInvoicePdf résout donc à `undefined` sur
-    // échec, pas à la chaîne '' que onError retourne.
+    // apiCall (fabrique) attend `onError` : son message d'erreur (calculé via
+    // un `await` interne, lecture d'un blob JSON) finit dans errors.pdf/notify
+    // avant qu'apiCall ne résolve. apiCall lui-même ne renvoie rien sur échec
+    // (`undefined`) ; c'est getInvoicePdf qui traduit cette absence de réponse
+    // en chaîne vide, après l'appel.
     const resultat = await store.getInvoicePdf(1);
 
-    expect(resultat).toBeUndefined();
+    expect(resultat).toBe('');
     expect(store.errors.pdf).toBe('Votre profil est incomplet. Complétez vos informations dans les paramètres.');
     // La branche générique n'est jamais atteinte : pas de validationErrors.
     expect(store.errors.validationErrors).toBeUndefined();

--- a/resources/js/stores/prestations.js
+++ b/resources/js/stores/prestations.js
@@ -10,7 +10,7 @@ export const usePrestationsStore = defineStore('prestations', () => {
   const errors = ref({});
   const loading = ref({});
 
-  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
+  const { apiCall, clearErrors } = creerApiCall({ errors, loading });
 
   // Filtres pour les prestations (par exemple, filtrer par date et adresse)
   const activeFilters = ref({

--- a/resources/js/stores/prestations.js
+++ b/resources/js/stores/prestations.js
@@ -3,11 +3,14 @@ import { ref, computed, watch } from 'vue';
 import axios from 'axios';
 import { notify } from '@/utils';
 import dayjs from 'dayjs';
+import { creerApiCall } from '@/stores/apiCall';
 
 export const usePrestationsStore = defineStore('prestations', () => {
   const prestations = ref([]);
   const errors = ref({});
   const loading = ref({});
+
+  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
 
   // Filtres pour les prestations (par exemple, filtrer par date et adresse)
   const activeFilters = ref({
@@ -53,37 +56,6 @@ export const usePrestationsStore = defineStore('prestations', () => {
   const unbilledPrestations = computed(() => {
     return prestations.value.filter((prestation) => prestation.facture_id == null);
   });
-
-  function clearErrors(operation) {
-    if (operation) {
-      errors.value[operation] = null;
-    } else {
-      errors.value = {};
-    }
-  }
-
-  function setLoading(operation, state) {
-    loading.value[operation] = state;
-  }
-
-  async function apiCall({ operation, request, onSuccess }) {
-    clearErrors(operation);
-    setLoading(operation, true);
-    try {
-      const response = await request();
-      if (onSuccess) onSuccess(response);
-      return response;
-    } catch (err) {
-      if (err.response?.status === 422) {
-        errors.value.validationErrors = err.response.data.errors;
-      } else {
-        errors.value[operation] = err.response?.data?.message || "Une erreur est survenue.";
-        notify('error', errors.value[operation]);
-      }
-    } finally {
-      setLoading(operation, false);
-    }
-  }
 
   async function fetchPrestations() {
     return apiCall({

--- a/resources/js/stores/taux-horaires.js
+++ b/resources/js/stores/taux-horaires.js
@@ -2,11 +2,14 @@ import { defineStore } from 'pinia';
 import { ref, computed, watch } from 'vue';
 import axios from 'axios';
 import { notify } from '@/utils';
+import { creerApiCall } from '@/stores/apiCall';
 
 export const useTauxHorairesStore = defineStore('taux-horaires', () => {
   const tauxHoraires = ref([]);
   const errors = ref({});
   const loading = ref({});
+
+  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
 
   /*
   const activeFilters = useStorage("prestation-filters", {
@@ -44,37 +47,6 @@ export const useTauxHorairesStore = defineStore('taux-horaires', () => {
     return prestations.value.filter((prestation) => !prestation.facture_id);
   });
   */
-
-  function clearErrors(operation) {
-    if (operation) {
-      errors.value[operation] = null;
-    } else {
-      errors.value = {};
-    }
-  }
-
-  function setLoading(operation, state) {
-    loading.value[operation] = state;
-  }
-
-  async function apiCall({ operation, request, onSuccess }) {
-    clearErrors(operation);
-    setLoading(operation, true);
-    try {
-      const response = await request();
-      if (onSuccess) onSuccess(response);
-      return response;
-    } catch (err) {
-      if (err.response?.status === 422) {
-        errors.value.validationErrors = err.response.data.errors;
-      } else {
-        errors.value[operation] = err.response?.data?.message || "Une erreur est survenue.";
-        notify('error', errors.value[operation]);
-      }
-    } finally {
-      setLoading(operation, false);
-    }
-  }
 
   async function fetchTauxHoraires() {
     return apiCall({

--- a/resources/js/stores/taux-horaires.js
+++ b/resources/js/stores/taux-horaires.js
@@ -9,7 +9,7 @@ export const useTauxHorairesStore = defineStore('taux-horaires', () => {
   const errors = ref({});
   const loading = ref({});
 
-  const { apiCall, clearErrors, setLoading } = creerApiCall({ errors, loading });
+  const { apiCall, clearErrors } = creerApiCall({ errors, loading });
 
   /*
   const activeFilters = useStorage("prestation-filters", {


### PR DESCRIPTION
`apiCall` — la fonction qui enveloppe chaque appel API d'un store (chargement, erreurs, notifications) — était **copiée dans cinq stores**, avec `clearErrors` et `setLoading`. Trois copies étaient identiques **caractère pour caractère**. Une avait **divergé** :

```js
// Les quatre conformes
if (onSuccess) onSuccess(response);
return response;

// factures
return onSuccess ? onSuccess(response) : response;   // ← retourne le résultat de onSuccess
```

**Cette divergence a produit un bug réel.** `addInvoice` retournait ce que retournait *son* `onSuccess` — c'est-à-dire `undefined`, faute de `return`. La modale de création de facture ne pouvait donc pas distinguer un succès d'un échec : elle se fermait dans les deux cas, effaçant la sélection de l'utilisateur (jusqu'à 25 prestations à recocher). Le correctif d'alors — ajouter un `return true` — était un pansement sur le symptôme.

**La duplication était la cause.** Cette PR la supprime.

## Ce que ça change

Une fabrique `creerApiCall({ errors, loading, relancerLesErreurs })` que les cinq stores utilisent. Elle porte le comportement des **quatre stores conformes** ; c'est `factures` qui s'aligne.

Elle absorbe les deux besoins réels : `onError` (dont `getInvoicePdf` a besoin pour lire un message d'erreur dans un blob) et `relancerLesErreurs`, que seul `auth` active.

**Solde : −50 lignes**, et plus aucune copie d'`apiCall`.

## Le refactor est prouvé, pas supposé

Une PR précédente (#29) a écrit **52 tests de caractérisation** décrivant le comportement *existant* de chaque store, divergences comprises. Ils ont servi de juge.

**Résultat : trois tests ont cassé — tous dans `factures.test.js`, tous liés à la divergence.** Aucun autre store n'a rougi. Le refactor a donc changé exactement ce qui était décidé, et rien d'autre. Les trois tests ont été récrits pour décrire le nouveau comportement (ils assertent d'ailleurs **plus fort** qu'avant : la réponse complète, au lieu d'un simple `true`).

**`git diff main --name-only -- '*.test.js'` ne montre que `factures.test.js`** : aucun autre test n'a été « ajusté » pour passer.

## Les trois changements de comportement, tous dans `factures.js`

1. `apiCall` retourne la réponse → le `return true` d'`addInvoice` (le pansement) est retiré.
2. `getInvoicePdf` construit l'URL de son blob **après** l'appel.
3. **`onError` est désormais attendu (`await`)** — et ça corrige un vrai bug : sans lui, `apiCall` résolvait **avant** qu'`onError` ait fini de lire le blob. Un PDF refusé en 403 affichait une modale **entièrement vide** (ni message, ni spinner) avant que l'erreur ne surgisse après coup.

## Deux dettes délibérément figées

Elles restent **intactes**, et leurs tests verts — les corriger ici aurait mélangé un refactor (aucun changement de comportement) et des corrections de bugs :

- `auth.updateUser()` ne met **jamais** à jour `store.user` : le paramètre masque la ref du store.
- `errors.validationErrors` n'est **jamais vidé** par `clearErrors`.

## Vérifications

La revue a validé la fabrique par **mutation testing** — injecter des défauts et vérifier que le filet les attrape :

| Mutation | Tests rouges |
|---|---|
| retrait du `finally setLoading(false)` | 10 |
| inversion de `relancerLesErreurs` | 21 |
| restauration de la divergence de `factures` | 6 |
| `clearErrors()` viderait `validationErrors` | 4 |
| retrait du `notify` d'erreur | 5 |
| `422` → `400` | 7 |
| **retrait du `await onError`** | **0** ← trou comblé |

La seule mutation qui survivait est désormais couverte : retirer le `await` fait rougir un test, et lui seul.

- `npm run test` → **53 tests verts**.
- `php artisan test` → 90 verts (backend intact).
- `npm run build` → passe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj