### PR TITLE
Sécurité : durcir la porte d'entrée de l'authentification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# Origine autorisée pour les requêtes CORS authentifiées (le front).
+FRONTEND_URL=http://localhost
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/.env.production.example
+++ b/.env.production.example
@@ -40,6 +40,7 @@ SESSION_DRIVER=database
 SESSION_LIFETIME=120
 SESSION_DOMAIN=promeb.hotel-longchamps.fr
 SANCTUM_STATEFUL_DOMAINS=promeb.hotel-longchamps.fr
+FRONTEND_URL=https://promeb.hotel-longchamps.fr
 
 CACHE_STORE=database
 QUEUE_CONNECTION=database

--- a/.env.production.example
+++ b/.env.production.example
@@ -39,6 +39,8 @@ MYSQL_ROOT_PASSWORD=change_me_root
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
 SESSION_DOMAIN=promeb.hotel-longchamps.fr
+# Le cookie de session n'est transmis que sur HTTPS (obligatoire en production).
+SESSION_SECURE_COOKIE=true
 SANCTUM_STATEFUL_DOMAINS=promeb.hotel-longchamps.fr
 FRONTEND_URL=https://promeb.hotel-longchamps.fr
 

--- a/app/Console/Commands/CreateUser.php
+++ b/app/Console/Commands/CreateUser.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
 
 class CreateUser extends Command implements PromptsForMissingInput
 {
@@ -42,7 +43,7 @@ class CreateUser extends Command implements PromptsForMissingInput
         $validator = Validator::make(compact('name', 'email', 'password'), [
             'name' => 'required|string|max:255',
             'email' => 'required|email|unique:users,email',
-            'password' => 'required|string|min:2',
+            'password' => ['required', 'string', Password::min(12)],
         ]);
 
         if ($validator->fails()) {

--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -5,10 +5,28 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
 {
+    /**
+     * Nom du limiteur nommé défini dans AppServiceProvider::boot()
+     * et référencé par le middleware `throttle:login` (routes/api.php).
+     */
+    public const THROTTLE_LIMITER = 'login';
+
+    /**
+     * Clé de limitation du login : couple email + IP.
+     * Source unique de vérité, utilisée par le limiteur (AppServiceProvider)
+     * ET par la remise à zéro ci-dessous. Les deux DOIVENT rester identiques.
+     */
+    public static function cleThrottle(Request $request): string
+    {
+        return Str::lower((string) $request->input('email')) . '|' . $request->ip();
+    }
+
     public function login(Request $request) {
         $credentials = $request->validate([
             'email' => ['required', 'email'],
@@ -16,7 +34,19 @@ class AuthController extends Controller
         ]);
 
         if(Auth::attempt($credentials)) {
-            $request->session()->regenerate();
+            // Le middleware `throttle:login` hache la clé du limiteur nommé avec
+            // md5(nom_du_limiteur . cle) avant de la stocker en cache (voir
+            // Illuminate\Routing\Middleware\ThrottleRequests::handleRequestUsingNamedLimiter).
+            // RateLimiter::clear() ne fait, lui, aucun hachage : pour cibler la même
+            // entrée de cache, il faut reproduire exactement cette transformation ici.
+            RateLimiter::clear(
+                md5(self::THROTTLE_LIMITER . self::cleThrottle($request))
+            );
+
+            if ($request->hasSession()) {
+                $request->session()->regenerate();
+            }
+
             return response()->noContent();
         }
 

--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -21,10 +21,28 @@ class AuthController extends Controller
      * Clé de limitation du login : couple email + IP.
      * Source unique de vérité, utilisée par le limiteur (AppServiceProvider)
      * ET par la remise à zéro ci-dessous. Les deux DOIVENT rester identiques.
+     *
+     * Exécutée par le middleware `throttle:login` AVANT la validation du
+     * contrôleur : `email` peut donc arriver ici sous n'importe quelle forme
+     * (tableau, null, etc.), pas seulement une chaîne. Ne jamais faire
+     * `(string) $request->input('email')` sans vérifier le type d'abord —
+     * un tableau déclenche un `E_WARNING: Array to string conversion` promu
+     * en `ErrorException` (500), et comme l'exception part avant que le
+     * `Limit` ne soit retourné, `hit()` n'est jamais appelé : la tentative
+     * échappe au throttle.
+     *
+     * Partie IP : n'est fiable que si `bootstrap/app.php` déclare les
+     * proxies de confiance (`trustProxies`). Sans ça, en prod derrière le
+     * Nginx du VPS, `$request->ip()` renvoie l'IP du proxy (constante pour
+     * tous les clients) et la clé dégénère de fait en `email` seul — voir
+     * docs/securite/throttle-vraie-ip-client.md pour la mise à niveau.
      */
     public static function cleThrottle(Request $request): string
     {
-        return Str::lower((string) $request->input('email')) . '|' . $request->ip();
+        $email = $request->input('email');
+        $email = is_string($email) ? Str::lower($email) : '';
+
+        return $email . '|' . $request->ip();
     }
 
     public function login(Request $request) {

--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -39,6 +39,15 @@ class AuthController extends Controller
             // Illuminate\Routing\Middleware\ThrottleRequests::handleRequestUsingNamedLimiter).
             // RateLimiter::clear() ne fait, lui, aucun hachage : pour cibler la même
             // entrée de cache, il faut reproduire exactement cette transformation ici.
+            //
+            // ATTENTION : ce md5(THROTTLE_LIMITER . cle) reproduit un détail d'implémentation
+            // interne de Laravel, non contractuel (non documenté, non garanti stable entre
+            // versions). Si une future version de Laravel change ce hachage, cette remise à
+            // zéro échouera silencieusement en production (le compteur ne sera plus effacé,
+            // sans erreur ni log). Seul le test « une connexion reussie remet le compteur a
+            // zero » (tests/Feature/LoginThrottleTest.php) peut détecter cette régression :
+            // si ce test casse après une montée de version de Laravel, c'est ici qu'il faut
+            // regarder en premier.
             RateLimiter::clear(
                 md5(self::THROTTLE_LIMITER . self::cleThrottle($request))
             );

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\API\AuthController;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for(AuthController::THROTTLE_LIMITER, function (Request $request) {
+            return Limit::perMinute(5)->by(AuthController::cleThrottle($request));
+        });
     }
 }

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => array_filter([env('FRONTEND_URL', env('APP_URL'))]),
 
     'allowed_origins_patterns' => [],
 

--- a/docs/securite/throttle-vraie-ip-client.md
+++ b/docs/securite/throttle-vraie-ip-client.md
@@ -1,0 +1,234 @@
+# Faire remonter la vraie IP client jusqu'au throttle de login
+
+Contexte : `AuthController::cleThrottle()` construit la clé du rate limiter de
+login avec `email + IP` (voir
+`docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md`). En
+production, tant que les trois couches ci-dessous ne sont pas configurées,
+`$request->ip()` renvoie l'IP du **proxy Nginx du VPS**, constante pour tous
+les clients — la clé dégénère de fait en `email` seul. Ce n'est pas une faille
+(l'anti-force-brute par email fonctionne toujours), mais le bénéfice du
+`+ IP` (empêcher un attaquant de bloquer volontairement le compte d'autrui en
+DoS ciblé) n'est atteint qu'une fois ce guide appliqué.
+
+Ce document explique, couche par couche, comment faire remonter la vraie IP
+du client jusqu'à `$request->ip()` dans Laravel. Il est autosuffisant : pas
+besoin d'avoir suivi le reste du projet pour le dérouler.
+
+## Vue d'ensemble du trajet d'une requête
+
+```
+Client → Nginx du VPS (reverse proxy, hors dépôt)
+       → Nginx du container `promeb_nginx` (nginx/default.prod.conf, dans le dépôt)
+       → PHP-FPM `promeb_app` → Laravel (bootstrap/app.php)
+```
+
+Chaque saut ajoute une couche réseau entre le client et Laravel. Sans rien
+configurer, chaque couche voit l'IP du sauteur précédent, pas celle du client
+d'origine. Il faut :
+
+1. Que le premier saut (Nginx du VPS) note l'IP réelle du client dans un
+   en-tête HTTP (`X-Forwarded-For`, `X-Real-IP`).
+2. Que le deuxième saut (Nginx du container) transmette cet en-tête et
+   l'utilise pour renseigner `REMOTE_ADDR` côté PHP.
+3. Que Laravel fasse confiance à ce `REMOTE_ADDR`-là (et seulement à
+   celui-là) pour peupler `$request->ip()`.
+
+Sauter une étape casse la chaîne (l'IP ne remonte pas) ; mal faire l'étape 3
+(faire confiance à n'importe qui) ouvre une faille pire que le problème
+d'origine — voir l'avertissement en fin de document.
+
+## 1. Nginx du VPS (reverse proxy, hors dépôt)
+
+Ce fichier vit sur le VPS Infine, pas dans ce dépôt (c'est le proxy qui route
+`promeb.hotel-longchamps.fr` vers le container `promeb_nginx`). Il doit
+transmettre l'IP réelle du client aux en-têtes standard :
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name promeb.hotel-longchamps.fr;
+
+    location / {
+        proxy_pass http://promeb_nginx:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+- `$remote_addr` est l'IP du client tel que vu par ce Nginx (le premier saut
+  ne peut pas se faire mentir dessus au niveau TCP).
+- `$proxy_add_x_forwarded_for` ajoute `$remote_addr` à un éventuel
+  `X-Forwarded-For` déjà présent dans la requête entrante (plutôt que de
+  l'écraser), ce qui garde une chaîne cohérente si jamais un autre
+  intermédiaire existe en amont.
+
+**Vérifier / ajouter** : se connecter au VPS, ouvrir le `server {}` qui route
+vers `promeb_nginx`, confirmer la présence des trois `proxy_set_header`
+ci-dessus. C'est probablement déjà fait pour d'autres projets sur ce VPS
+(pattern standard, voir `CLAUDE.md`) — mais à vérifier explicitement pour
+`promeb.hotel-longchamps.fr`, ne pas supposer.
+
+Recharger après modification :
+
+```bash
+nginx -t && systemctl reload nginx
+```
+
+## 2. Nginx du container (`nginx/default.prod.conf`, dans le dépôt)
+
+Ce Nginx-là reçoit la requête du Nginx du VPS via le réseau Docker partagé
+`sites_network` (voir `docker-compose.production.yml`). Par défaut, PHP-FPM
+verra `REMOTE_ADDR` = l'IP du Nginx du VPS sur ce réseau Docker, pas celle du
+client. Il faut dire à ce Nginx : « fais confiance à l'en-tête
+`X-Forwarded-For` envoyé par le Nginx du VPS, et remplace `$remote_addr` par
+la vraie IP qu'il contient » — c'est le rôle du module `ngx_http_realip_module`
+(inclus par défaut dans l'image `nginx:alpine`).
+
+Ajouter dans le bloc `server {}` de `nginx/default.prod.conf` :
+
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name promeb.hotel-longchamps.fr www.promeb.hotel-longchamps.fr;
+    root /var/www/html/public;
+
+    # Ne faire confiance qu'aux en-têtes X-Forwarded-For envoyés depuis le
+    # réseau Docker partagé sites_network (là où vit le Nginx du VPS côté
+    # container) — jamais depuis n'importe quelle IP (voir avertissement
+    # plus bas sur le "*").
+    set_real_ip_from 172.16.0.0/12;   # plage par défaut des réseaux Docker
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    # ... reste du fichier inchangé
+```
+
+**Comment trouver le réseau à mettre dans `set_real_ip_from`** :
+
+```bash
+docker network inspect sites_network --format '{{ (index .IPAM.Config 0).Subnet }}'
+```
+
+Cette commande affiche le sous-réseau réellement attribué à `sites_network`
+sur le VPS (souvent une plage `172.x.0.0/16` ou similaire — les réseaux
+Docker par défaut piochent dans `172.16.0.0/12`, mais **vérifier la valeur
+réelle plutôt que de la supposer**, elle peut varier selon ce qui est déjà
+alloué sur l'hôte). Remplacer `172.16.0.0/12` ci-dessus par le résultat exact
+de cette commande si possible — une plage plus précise que la totalité de
+`172.16.0.0/12` réduit la surface si un jour un container compromis se trouve
+sur le même réseau Docker.
+
+`real_ip_recursive on` permet de remonter la chaîne `X-Forwarded-For` si elle
+contient plusieurs IP (utile si un jour un CDN ou un autre proxy s'ajoute
+devant le Nginx du VPS) en ignorant les IP qui appartiennent elles-mêmes à des
+plages de confiance, pour ne garder que la première IP externe.
+
+Ce changement est dans le dépôt : il part avec le build de l'image
+`promeb_nginx` (`Dockerfile.prod`, stage `nginx_app`), donc un simple
+redéploiement (`deploy.sh` → `docker compose build && docker compose up -d`)
+suffit à l'appliquer.
+
+## 3. Laravel (`bootstrap/app.php`)
+
+Une fois `REMOTE_ADDR` correct au niveau de PHP-FPM (étape 2), il reste à dire
+à Laravel qu'il peut faire confiance à cette valeur. Par défaut, le
+middleware `TrustProxies` de Laravel ignore tous les en-têtes `Forwarded` /
+`X-Forwarded-*` sauf s'il connaît explicitement l'IP (ou la plage) de qui les
+envoie — ici, le container `promeb_nginx` lui-même (le seul intermédiaire que
+PHP-FPM voit directement).
+
+Dans `bootstrap/app.php` :
+
+```php
+use Illuminate\Http\Request;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(/* ... inchangé ... */)
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->statefulApi();
+
+        $middleware->trustProxies(
+            at: '172.16.0.0/12', // même réseau sites_network que l'étape 2
+            headers: Request::HEADER_X_FORWARDED_FOR
+                | Request::HEADER_X_FORWARDED_HOST
+                | Request::HEADER_X_FORWARDED_PORT
+                | Request::HEADER_X_FORWARDED_PROTO,
+        );
+    })
+    ->withExceptions(function (Exceptions $exceptions) {
+        //
+    })->create();
+```
+
+Remplacer `172.16.0.0/12` par le sous-réseau exact de `sites_network` trouvé à
+l'étape 2 (idéalement la même valeur des deux côtés, pour cohérence).
+
+### Pourquoi jamais `at: '*'`
+
+`trustProxies(at: '*')` dit à Laravel : « fais confiance à l'en-tête
+`X-Forwarded-For` peu importe qui envoie la requête ». Or `X-Forwarded-For`
+est un en-tête HTTP **ordinaire**, entièrement contrôlable par le client — y
+compris un attaquant qui parle directement à `promeb_nginx` (ou même à
+Laravel, si jamais un port est exposé sans passer par le VPS). Avec `at: '*'`
+en place :
+
+1. L'attaquant envoie `POST /api/auth/login` avec
+   `X-Forwarded-For: 1.2.3.4` (une IP qu'il invente).
+2. Laravel fait confiance à cet en-tête : `$request->ip()` renvoie
+   `1.2.3.4`.
+3. La clé du throttle devient `email|1.2.3.4` — neuve, jamais vue.
+4. L'attaquant recommence avec `X-Forwarded-For: 1.2.3.5`, `.6`, `.7`, …
+   à chaque tentative : chaque requête obtient un compteur de throttle
+   vierge.
+5. Le rate limiting `email + IP` est **entièrement contourné** — pire que
+   l'absence du `+ IP` documentée dans la spec (qui, elle, retombe sur un
+   throttle par email toujours effectif).
+
+`at: '<réseau sites_network>'` limite la confiance au seul expéditeur légitime
+de cet en-tête dans notre topologie (le container `promeb_nginx`, qui lui-même
+ne transmet que ce que le Nginx du VPS lui a envoyé, qui lui-même a écrit
+`$remote_addr` — une valeur que le client ne peut pas falsifier au niveau
+TCP). Un attaquant qui contacte directement `promeb_app` ou `promeb_nginx`
+sans passer par le VPS n'est pas dans cette plage : son `X-Forwarded-For`
+est ignoré, et `$request->ip()` retombe sur l'IP de connexion réelle (la
+sienne, ou celle du Nginx du VPS s'il passe par le chemin normal).
+
+## Comment vérifier que ça fonctionne
+
+Après avoir appliqué les trois couches et redéployé :
+
+1. Ajouter temporairement une route de diagnostic (à retirer après le test,
+   ne jamais la laisser en prod) :
+
+   ```php
+   // routes/web.php ou routes/api.php, temporaire
+   Route::get('/debug-ip', fn (Request $request) => $request->ip());
+   ```
+
+2. Depuis **deux machines différentes** (deux réseaux différents — par
+   exemple son poste et un téléphone en 4G, ou deux VPN différents), visiter
+   `https://promeb.hotel-longchamps.fr/debug-ip`.
+
+3. Constater que :
+   - Les deux réponses affichent des IP **différentes** entre elles.
+   - Aucune des deux IP n'est celle du container (`docker network inspect
+     sites_network` pour comparer, ou `docker exec promeb_nginx hostname -i`).
+   - L'IP affichée correspond à l'IP publique réelle de la machine utilisée
+     (vérifiable via `curl ifconfig.me` depuis cette même machine).
+
+4. Retirer la route de diagnostic une fois la vérification faite.
+
+Si les deux réponses affichent la **même** IP (ou l'IP du container), une des
+trois couches n'est pas configurée correctement — reprendre dans l'ordre
+Nginx VPS → Nginx container → Laravel, chacune ne pouvant fonctionner que si
+la précédente le fait.
+
+Une fois ces trois couches en place et vérifiées, retirer la note ajoutée
+dans `docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md`
+(section « Rate limiting : clé `email + IP` ») : le compromis `email + IP`
+sera alors réellement tenu en production.

--- a/docs/superpowers/plans/2026-07-14-securite-auth-serveur.md
+++ b/docs/superpowers/plans/2026-07-14-securite-auth-serveur.md
@@ -1,0 +1,488 @@
+# Sécurité serveur de l'authentification — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Durcir la porte d'entrée : rate limiting sur le login, CORS restreint, logout qui ne plante plus, cookie `Secure` en prod, mot de passe d'au moins 12 caractères.
+
+**Architecture :** Cinq corrections indépendantes, du backend et de la config. Le rate limiter est un `RateLimiter` nommé enregistré dans `AppServiceProvider`, appliqué par middleware sur la route de login. Le reste est de la config (CORS lu depuis le `.env`, route logout déplacée, variables d'environnement).
+
+**Tech Stack :** Laravel 12 (PHP 8.4), Pest, Sanctum (session).
+
+## Global Constraints
+
+- Spec de référence : `docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md`
+- **Rate limiting : clé `email + IP`**, 5 tentatives par minute. La clé DOIT être construite de façon **identique** dans le limiteur (`AppServiceProvider`) et dans le contrôleur (pour la remise à zéro au succès). Centraliser sa construction dans une seule méthode statique pour qu'il n'existe qu'une définition.
+- **La remise à zéro au succès est explicite** : `throttle` incrémente à chaque requête, y compris une connexion réussie. `AuthController::login` appelle `RateLimiter::clear(clé)` après `Auth::attempt` réussi, sinon une connexion valide consommerait un jeton.
+- **CORS : origines pilotées par le `.env`** via `FRONTEND_URL` (défaut `APP_URL`). Jamais `['*']` avec `supports_credentials`.
+- **Mot de passe : `Password::min(12)`** (longueur seule, pas de complexité imposée) dans `user:create`.
+- Le message de blocage du throttle reste celui de Laravel (générique) : le front l'affiche déjà via son traitement d'erreur.
+- Tests : Pest, `php artisan test --testsuite=Feature`. **Jamais `php artisan test` sans `--testsuite=Feature`** (la suite `Unit` déclarée dans phpunit.xml pointe sur un dossier qui n'existe pas — préexistant, hors périmètre). En test, `CACHE_STORE=array` : le RateLimiter repart vide à chaque test (instance d'app neuve), donc pas de nettoyage inter-tests nécessaire. Point de départ : 90 tests verts.
+- Le cookie `Secure` et HSTS ne sont **pas testables en CI** (variables du `.env` de prod, absentes de l'environnement de test) : vérifiés par lecture du modèle et une note de déploiement.
+- Commits en français, format `type: description`.
+
+---
+
+### Task 1 : Rate limiting sur le login
+
+Le cœur du lot. Un limiteur `login` clé `email + IP`, avec remise à zéro au succès.
+
+**Files:**
+- Modify: `app/Providers/AppServiceProvider.php`
+- Modify: `app/Http/Controllers/API/AuthController.php`
+- Modify: `routes/api.php`
+- Test: `tests/Feature/LoginThrottleTest.php`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: `AuthController::cleThrottle(Request): string` — la clé `email + IP`, source unique de vérité, réutilisée par le limiteur et par la remise à zéro.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/Feature/LoginThrottleTest.php` :
+
+```php
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('bloque la connexion apres 5 tentatives echouees (429 a la 6e)', function () {
+    User::factory()->create([
+        'email'    => 'victime@promeb.fr',
+        'password' => bcrypt('le-vrai-mot-de-passe'),
+    ]);
+
+    // 5 tentatives échouées : refusées (422), mais pas encore bloquées.
+    for ($i = 1; $i <= 5; $i++) {
+        $this->postJson('/api/auth/login', [
+            'email'    => 'victime@promeb.fr',
+            'password' => 'mauvais',
+        ])->assertStatus(422);
+    }
+
+    // La 6e est bloquée par le limiteur.
+    $this->postJson('/api/auth/login', [
+        'email'    => 'victime@promeb.fr',
+        'password' => 'mauvais',
+    ])->assertStatus(429);
+});
+
+it('ne bloque pas une autre adresse IP pour le meme email', function () {
+    User::factory()->create([
+        'email'    => 'victime@promeb.fr',
+        'password' => bcrypt('le-vrai-mot-de-passe'),
+    ]);
+
+    // 5 échecs depuis une première IP.
+    for ($i = 1; $i <= 5; $i++) {
+        $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.1'])
+            ->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+            ->assertStatus(422);
+    }
+
+    // Une IP différente sur le même email n'est pas bloquée : la clé (email+IP) change.
+    $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.2'])
+        ->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+        ->assertStatus(422);
+});
+
+it('une connexion reussie remet le compteur a zero', function () {
+    User::factory()->create([
+        'email'    => 'victime@promeb.fr',
+        'password' => bcrypt('le-bon-mot-de-passe'),
+    ]);
+
+    // 4 échecs.
+    for ($i = 1; $i <= 4; $i++) {
+        $this->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+            ->assertStatus(422);
+    }
+
+    // Une réussite doit effacer l'ardoise.
+    $this->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'le-bon-mot-de-passe'])
+        ->assertNoContent();
+
+    // Après quoi on doit pouvoir de nouveau échouer 5 fois sans être bloqué :
+    // si la remise à zéro n'a pas eu lieu, la 2e de ces tentatives (6e cumulée) serait un 429.
+    for ($i = 1; $i <= 5; $i++) {
+        $this->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+            ->assertStatus(422);
+    }
+});
+```
+
+> Note : ces tests exercent l'API réelle. `withServerVariables(['REMOTE_ADDR' => …])` fixe l'IP vue par `$request->ip()`. Le login réussi répond 204 (`assertNoContent`) — c'est ce que fait déjà `AuthController::login`.
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/LoginThrottleTest.php`
+Expected: FAIL. Le premier test attend un 429 à la 6ᵉ tentative mais reçoit un 422 (aucun throttle). Le troisième échoue aussi (sans remise à zéro explicite, il n'atteint pas le comportement attendu).
+
+- [ ] **Step 3: Enregistrer le limiteur**
+
+Dans `app/Providers/AppServiceProvider.php`, ajouter les imports et définir le limiteur dans `boot()` :
+
+```php
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use App\Http\Controllers\API\AuthController;
+```
+
+```php
+    public function boot(): void
+    {
+        RateLimiter::for('login', function (Request $request) {
+            return Limit::perMinute(5)->by(AuthController::cleThrottle($request));
+        });
+    }
+```
+
+- [ ] **Step 4: Centraliser la clé et remettre le compteur à zéro au succès**
+
+Dans `app/Http/Controllers/API/AuthController.php`, ajouter les imports :
+
+```php
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+```
+
+Ajouter la méthode statique — **la seule** définition de la clé — et vider le compteur au succès :
+
+```php
+    /**
+     * Clé de limitation du login : couple email + IP.
+     * Source unique de vérité, utilisée par le limiteur (AppServiceProvider)
+     * ET par la remise à zéro ci-dessous. Les deux DOIVENT rester identiques.
+     */
+    public static function cleThrottle(Request $request): string
+    {
+        return Str::lower((string) $request->input('email')) . '|' . $request->ip();
+    }
+
+    public function login(Request $request) {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if(Auth::attempt($credentials)) {
+            RateLimiter::clear(AuthController::cleThrottle($request));
+            $request->session()->regenerate();
+            return response()->noContent();
+        }
+
+        throw ValidationException::withMessages([
+            'email' => 'The provided credentials are incorrect.'
+        ]);
+    }
+```
+
+> Le message d'erreur reste inchangé (anglais) : sa francisation est dans le lot front, hors périmètre ici.
+
+- [ ] **Step 5: Appliquer le middleware sur la route**
+
+Dans `routes/api.php`, ajouter `throttle:login` à la route de login :
+
+```php
+        Route::post('/login', [AuthController::class, 'login'])
+            ->name('login')
+            ->middleware('throttle:login');
+```
+
+- [ ] **Step 6: Lancer les tests et vérifier qu'ils passent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/LoginThrottleTest.php`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 7: Lancer la suite complète**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 93 tests (90 + 3).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/Providers/AppServiceProvider.php app/Http/Controllers/API/AuthController.php routes/api.php tests/Feature/LoginThrottleTest.php
+git commit -m "feat: limite les tentatives de connexion (throttle par email + IP)"
+```
+
+---
+
+### Task 2 : Le logout ne plante plus
+
+**Files:**
+- Modify: `routes/api.php`
+- Test: `tests/Feature/LogoutTest.php`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: rien.
+
+Aujourd'hui la route `logout` est hors du groupe `auth:sanctum`, et `Auth::logout()` sans session lève une erreur 500. La déplacer dans le groupe fait qu'un logout non authentifié reçoit un 401 propre.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/Feature/LogoutTest.php` :
+
+```php
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('deconnecte un utilisateur authentifie', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson('/api/auth/logout')
+        ->assertNoContent();
+});
+
+it('repond 401 (et non 500) sur un logout sans session', function () {
+    $this->postJson('/api/auth/logout')
+        ->assertStatus(401);
+});
+```
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/LogoutTest.php`
+Expected: le second test ÉCHOUE — l'API renvoie un **500** au lieu du 401 attendu (`Auth::logout()` sans session). Le premier peut passer ou échouer selon la config actuelle.
+
+- [ ] **Step 3: Déplacer la route logout dans le groupe protégé**
+
+Dans `routes/api.php`, le groupe `auth` déclare aujourd'hui `login` ET `logout`. Sortir `logout` de ce groupe et la placer dans le groupe `Route::middleware('auth:sanctum')` existant (celui qui protège déjà `user`, `clients`, etc.).
+
+Concrètement :
+1. Retirer la ligne `logout` du groupe `Route::prefix('auth')`.
+2. À l'intérieur du groupe `Route::middleware('auth:sanctum')->group(function () { … })`, ajouter :
+
+```php
+    Route::post('/auth/logout', [AuthController::class, 'logout'])->name('auth.logout');
+```
+
+Le groupe `auth` ne contient alors plus que `login` (avec son `throttle:login`).
+
+> Vérifier que le chemin final reste `/api/auth/logout` (le préfixe `api` vient de `bootstrap/app.php`, `logout` doit garder son segment `auth/`).
+
+- [ ] **Step 4: Lancer les tests et vérifier qu'ils passent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/LogoutTest.php`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Lancer la suite complète**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 95 tests (93 + 2).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add routes/api.php tests/Feature/LogoutTest.php
+git commit -m "fix: le logout renvoie 401 au lieu de 500 sans session"
+```
+
+---
+
+### Task 3 : CORS restreint aux origines du front
+
+**Files:**
+- Modify: `config/cors.php`
+- Modify: `.env.example`
+- Modify: `.env.production.example`
+- Test: `tests/Feature/CorsTest.php`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: rien.
+
+`config/cors.php` autorise `['*']` avec `supports_credentials => true`. On restreint aux origines venues du `.env`.
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `tests/Feature/CorsTest.php` :
+
+```php
+<?php
+
+it('n\'autorise pas le joker comme origine CORS', function () {
+    // Une origine unique et explicite, jamais '*' : coupler '*' et
+    // supports_credentials laisse n'importe quel site lire les réponses authentifiées.
+    expect(config('cors.allowed_origins'))->not->toContain('*');
+});
+
+it('reflete uniquement l\'origine configuree, pas une origine etrangere', function () {
+    config()->set('cors.allowed_origins', ['https://promeb.example']);
+
+    $reponse = $this->call('OPTIONS', '/api/auth/login', [], [], [], [
+        'HTTP_ORIGIN'                         => 'https://evil.com',
+        'HTTP_ACCESS_CONTROL_REQUEST_METHOD'  => 'POST',
+    ]);
+
+    // L'origine étrangère ne doit PAS être renvoyée dans l'en-tête.
+    expect($reponse->headers->get('Access-Control-Allow-Origin'))->not->toBe('https://evil.com');
+});
+```
+
+> Le second test force une origine autorisée connue, puis vérifie qu'une origine étrangère n'est pas reflétée. Sur `main`, `allowed_origins` valant `['*']`, le premier test échoue déjà.
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/CorsTest.php`
+Expected: le premier test ÉCHOUE (`allowed_origins` contient `*`).
+
+- [ ] **Step 3: Restreindre les origines dans la config**
+
+Dans `config/cors.php`, remplacer la ligne `allowed_origins` :
+
+```php
+    'allowed_origins' => array_filter([env('FRONTEND_URL', env('APP_URL'))]),
+```
+
+`array_filter` retire un éventuel `null` (si ni `FRONTEND_URL` ni `APP_URL` n'est défini), pour ne pas produire `[null]`.
+
+- [ ] **Step 4: Documenter la variable dans les deux modèles d'environnement**
+
+Dans `.env.example`, ajouter sous la ligne `APP_URL` :
+
+```
+# Origine autorisée pour les requêtes CORS authentifiées (le front).
+FRONTEND_URL=http://localhost
+```
+
+Dans `.env.production.example`, ajouter près de `SESSION_DOMAIN` / `SANCTUM_STATEFUL_DOMAINS` :
+
+```
+FRONTEND_URL=https://promeb.hotel-longchamps.fr
+```
+
+- [ ] **Step 5: Lancer les tests et vérifier qu'ils passent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/CorsTest.php`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 6: Lancer la suite complète**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 97 tests (95 + 2).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add config/cors.php .env.example .env.production.example tests/Feature/CorsTest.php
+git commit -m "fix: restreint CORS a l'origine du front au lieu du joker"
+```
+
+---
+
+### Task 4 : Mot de passe d'au moins 12 caractères, et cookie Secure en prod
+
+Deux corrections de config groupées : la politique de mot de passe (testable) et le cookie `Secure` (une variable d'environnement).
+
+**Files:**
+- Modify: `app/Console/Commands/CreateUser.php`
+- Modify: `.env.production.example`
+- Test: `tests/Feature/CreateUserPasswordTest.php`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: rien (dernière tâche).
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/Feature/CreateUserPasswordTest.php` :
+
+```php
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('refuse un mot de passe de moins de 12 caracteres', function () {
+    $this->artisan('user:create', [
+        'name'     => 'Court',
+        'email'    => 'court@promeb.fr',
+        'password' => 'court',
+    ])->assertFailed();
+
+    expect(User::where('email', 'court@promeb.fr')->exists())->toBeFalse();
+});
+
+it('accepte un mot de passe de 12 caracteres ou plus', function () {
+    $this->artisan('user:create', [
+        'name'     => 'Correct',
+        'email'    => 'correct@promeb.fr',
+        'password' => 'motdepasse-solide',
+    ])->assertExitCode(0);
+
+    expect(User::where('email', 'correct@promeb.fr')->exists())->toBeTrue();
+});
+```
+
+> `assertFailed()` couvre le cas où la commande s'arrête via `$this->fail(...)`. Si la commande retourne un autre code d'échec, ajuster l'assertion — mais ne pas changer la logique de la commande au-delà de la règle de validation.
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/CreateUserPasswordTest.php`
+Expected: le premier test ÉCHOUE — un mot de passe de 5 caractères est accepté (`min:2`), donc l'utilisateur est créé.
+
+- [ ] **Step 3: Durcir la règle de validation**
+
+Dans `app/Console/Commands/CreateUser.php`, ajouter l'import :
+
+```php
+use Illuminate\Validation\Rules\Password;
+```
+
+Remplacer la règle du mot de passe dans le `Validator::make` :
+
+```php
+            'password' => ['required', 'string', Password::min(12)],
+```
+
+Longueur seule, sans complexité imposée — conforme à la décision de la spec.
+
+- [ ] **Step 4: Lancer les tests et vérifier qu'ils passent**
+
+Run: `php artisan test --testsuite=Feature tests/Feature/CreateUserPasswordTest.php`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Ajouter SESSION_SECURE_COOKIE au modèle de prod**
+
+Dans `.env.production.example`, ajouter près des autres variables `SESSION_` :
+
+```
+# Le cookie de session n'est transmis que sur HTTPS (obligatoire en production).
+SESSION_SECURE_COOKIE=true
+```
+
+> C'est une variable d'environnement, non testable en CI (qui tourne sans ce `.env`). Elle devra être **reportée dans le vrai `.env` du VPS** au prochain déploiement — c'est noté dans la vérification finale.
+
+- [ ] **Step 6: Lancer la suite complète**
+
+Run: `php artisan test --testsuite=Feature`
+Expected: PASS — 99 tests (97 + 2).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/Console/Commands/CreateUser.php .env.production.example tests/Feature/CreateUserPasswordTest.php
+git commit -m "fix: mot de passe min 12 caracteres et cookie de session Secure en prod"
+```
+
+---
+
+## Vérification finale
+
+- [ ] `php artisan test --testsuite=Feature` — 99 tests verts.
+- [ ] `grep -n "allowed_origins" config/cors.php` — lit `FRONTEND_URL`, plus de `['*']`.
+- [ ] `grep -rn "throttle:login" routes/api.php` — présent sur la route de login.
+- [ ] La clé `email + IP` n'est définie qu'à **un seul endroit** (`AuthController::cleThrottle`), utilisée par le limiteur et par la remise à zéro.
+- [ ] **Rappel de déploiement** (à faire sur le VPS, hors de cette PR) : reporter `FRONTEND_URL=https://promeb.hotel-longchamps.fr` et `SESSION_SECURE_COOKIE=true` dans le `.env` de production. Sans ça, la restriction CORS et le cookie `Secure` ne prennent pas effet en prod.

--- a/docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md
+++ b/docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md
@@ -50,6 +50,17 @@ attaquant pourrait bloquer volontairement le compte d'autrui — déni de servic
 ciblé). Le couple email+IP cible la force brute sans ces effets de bord. Une
 connexion réussie remet le compteur à zéro.
 
+> **Note (revue finale, 2026-07-15) : ce compromis n'est pas tenu en production
+> aujourd'hui.** L'app est derrière le Nginx du VPS sans `trustProxies` configuré
+> côté Laravel ni transmission de `X-Forwarded-For` côté Nginx du container. Dans
+> cet état, `$request->ip()` renvoie l'IP du proxy — constante pour tous les
+> clients — et la clé `email + IP` dégénère de fait en `email` seul. L'anti-force-
+> brute par email reste pleinement effectif ; c'est uniquement la protection contre
+> le déni de service ciblé sur le compte d'autrui (le bénéfice du `+ IP`) qui n'est
+> pas atteinte tant que l'infra n'est pas configurée. Décision : accepté tel quel
+> pour l'instant. Guide de mise à niveau :
+> `docs/securite/throttle-vraie-ip-client.md`.
+
 **CORS : liste des origines pilotée par le `.env`.** Cohérent avec la façon dont
 `SESSION_DOMAIN` et `SANCTUM_STATEFUL_DOMAINS` sont déjà gérés. Une variable
 `FRONTEND_URL` par environnement, plutôt qu'une liste en dur dans le code.

--- a/docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md
+++ b/docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md
@@ -1,0 +1,148 @@
+# Durcir la sécurité serveur de l'authentification
+
+Date : 2026-07-14
+
+## Problème
+
+Un audit de l'authentification (session Sanctum, Laravel 12 + Vue 3 SPA) a
+confirmé un socle sain — CSRF actif, pas d'IDOR sur le profil, fixation de session
+couverte, pas d'énumération de comptes — mais cinq défauts côté serveur, tous
+vérifiés en exerçant l'API réelle.
+
+### Critiques
+
+**1. Aucun rate limiting sur `POST /api/auth/login`.** En Laravel 11+, le groupe de
+middleware `api` n'applique plus `throttle` par défaut, et `bootstrap/app.php` ne
+fait que `$middleware->statefulApi()`. Prouvé : 30 tentatives échouées en ~9 s,
+aucun 429. La force brute est triviale et sans coût.
+
+**2. CORS ouvert à toutes les origines, avec credentials.** `config/cors.php` a
+`allowed_origins => ['*']` **et** `supports_credentials => true`. Prouvé : un
+preflight depuis `https://evil.com` reçoit `Access-Control-Allow-Origin: evil.com`
++ `Allow-Credentials: true`. Seul le cookie `SameSite=Lax` empêche aujourd'hui
+l'exploitation complète — une unique ligne de défense, qui sauterait si le cookie
+passait un jour en `SameSite=none`.
+
+### Importants
+
+**3. `POST /api/auth/logout` sans session → HTTP 500.** La route est hors du groupe
+`auth:sanctum`, et `Auth::logout()` échoue sans session (« Session store not set on
+request. »).
+
+**4. Cookie de session non `Secure` en production.** `SESSION_SECURE_COOKIE` est
+absent de `.env.production.example` ; sa valeur par défaut est `null`. Le cookie de
+session peut donc transiter en clair sur une requête HTTP (downgrade/MITM), malgré
+l'`APP_URL` en HTTPS.
+
+**5. Politique de mot de passe quasi inexistante.** `user:create` — le **seul**
+chemin de création de compte (pas d'inscription publique) — valide avec
+`min:2`. Prouvé : un mot de passe de 2 caractères est accepté. Cela sape entièrement
+la correction du rate limiting.
+
+## Décisions
+
+Cinq corrections, un seul thème : durcir la porte d'entrée. On ne touche pas à ce
+que l'audit a déclaré sain (CSRF, profil, fixation de session).
+
+**Rate limiting : clé `email + IP`.** Ni l'IP seule (deux utilisateurs derrière un
+même NAT se gêneraient ; des IP tournantes passent au travers), ni l'email seul (un
+attaquant pourrait bloquer volontairement le compte d'autrui — déni de service
+ciblé). Le couple email+IP cible la force brute sans ces effets de bord. Une
+connexion réussie remet le compteur à zéro.
+
+**CORS : liste des origines pilotée par le `.env`.** Cohérent avec la façon dont
+`SESSION_DOMAIN` et `SANCTUM_STATEFUL_DOMAINS` sont déjà gérés. Une variable
+`FRONTEND_URL` par environnement, plutôt qu'une liste en dur dans le code.
+
+**Mot de passe : longueur seule, 12 caractères.** Les recommandations actuelles
+(NIST) privilégient la longueur sur la complexité imposée — plus efficace, et moins
+pénible pour l'unique créateur de comptes (toi, via artisan).
+
+## Conception
+
+| # | Fichier | Changement |
+|---|---|---|
+| 1 | `app/Providers/AppServiceProvider.php` | Définir un `RateLimiter::for('login', …)` clé `email + IP`, 5 tentatives/minute |
+| 1 | `routes/api.php` | `->middleware('throttle:login')` sur la route de login |
+| 2 | `config/cors.php` | `allowed_origins` lit `FRONTEND_URL` (défaut `APP_URL`) au lieu de `['*']` |
+| 2 | `.env.example` | Documenter `FRONTEND_URL=http://localhost` |
+| 2 | `.env.production.example` | `FRONTEND_URL=https://promeb.hotel-longchamps.fr` |
+| 3 | `routes/api.php` | Déplacer la route `logout` dans le groupe `auth:sanctum` |
+| 4 | `.env.production.example` | Ajouter `SESSION_SECURE_COOKIE=true` |
+| 5 | `app/Console/Commands/CreateUser.php` | Règle `Password::min(12)` au lieu de `min:2` |
+
+### Le rate limiter
+
+Un limiteur nommé `login`, enregistré dans `AppServiceProvider::boot()` :
+
+```php
+RateLimiter::for('login', function (Request $request) {
+    $cle = Str::lower((string) $request->input('email')) . '|' . $request->ip();
+    return Limit::perMinute(5)->by($cle);
+});
+```
+
+Au-delà de 5 tentatives sur le même couple email+IP en une minute, Laravel renvoie
+automatiquement un **429** avec l'en-tête `Retry-After`. Le message reste celui de
+Laravel (générique) — le front l'affiche déjà via son propre traitement d'erreur.
+
+**La remise à zéro au succès est explicite, pas implicite.** Le middleware
+`throttle` incrémente le compteur à *chaque* requête, réussie ou non — une
+connexion valide consommerait donc un jeton sans le libérer. Pour qu'une connexion
+réussie « efface l'ardoise », `AuthController::login` appelle `RateLimiter::clear`
+sur la même clé (`email + IP`) juste après `Auth::attempt` réussi, avant de
+répondre. La clé est donc construite de façon identique dans le limiteur et dans le
+contrôleur : ce point est un risque (deux définitions de la même clé) — le plan
+devra soit centraliser la construction de la clé, soit la vérifier par un test qui
+prouve qu'une réussite remet bien le compteur à zéro.
+
+### CORS
+
+`config/cors.php`, `allowed_origins` :
+
+```php
+'allowed_origins' => array_filter([env('FRONTEND_URL', env('APP_URL'))]),
+```
+
+`array_filter` évite un tableau `[null]` si aucune des deux variables n'est
+définie. Une seule origine suffit (l'app a un seul front). Si un besoin
+multi-origines apparaissait, on passerait à une liste séparée par des virgules —
+hors périmètre aujourd'hui (YAGNI).
+
+### Le logout
+
+Déplacer la route dans le groupe `auth:sanctum` existant. Un logout sans session
+authentifiée renverra alors un **401** propre (géré par le middleware) au lieu d'un
+500. Le corps de `AuthController::logout` est inchangé : il ne s'exécute que si
+l'utilisateur est authentifié.
+
+## Tests
+
+Pest, `php artisan test`. Le CSRF n'est pas testable en Pest (le middleware se
+désactive sous les tests) — mais aucune de ces corrections n'en dépend pour être
+vérifiée.
+
+- **Rate limiting** : 5 tentatives échouées passent (422) ; la 6ᵉ est bloquée
+  (429). Une IP différente sur le même email n'est pas affectée (le couple change).
+  Le limiteur doit être **rendu déterministe** dans les tests (vider le cache du
+  limiteur entre les tests, ou utiliser `RateLimiter::clear`).
+- **Logout** : connecté → 204 ; non connecté → 401 (et non 500).
+- **Politique de mot de passe** : `user:create` refuse un mot de passe de moins de
+  12 caractères, accepte un mot de passe de 12+.
+- **CORS** : un test qui envoie une requête avec un `Origin` étranger et vérifie que
+  l'en-tête `Access-Control-Allow-Origin` ne le reflète pas. La config résolue
+  (`config('cors.allowed_origins')`) ne contient pas `*`.
+- **Cookie `Secure`** : c'est une variable d'environnement de production, non
+  testable en CI (qui tourne sans ce `.env`). Vérifié par lecture du modèle
+  `.env.production.example`, et par une note explicite : à reporter dans le `.env`
+  du VPS au déploiement.
+
+## Hors périmètre
+
+- Les points **front** de l'audit : intercepteur axios sur 401, revalidation de
+  `checkAuth`, message de login en français, état « connecté fantôme ». C'est le
+  lot suivant.
+- **HSTS** : à poser sur le reverse proxy Nginx du VPS (hors dépôt).
+- Le seeder de test (`DatabaseSeeder`) : `deploy.sh` ne l'exécute pas ; risque déjà
+  neutralisé.
+- Un endpoint de changement de mot de passe : n'existe pas, et n'est pas demandé.

--- a/routes/api.php
+++ b/routes/api.php
@@ -103,11 +103,14 @@ Route::middleware('auth:sanctum')->group(function () {
         });
 });
 
+Route::post('/auth/logout', [AuthController::class, 'logout'])
+    ->middleware('auth:web,sanctum')
+    ->name('auth.logout');
+
 Route::prefix('auth')
     ->as('auth.')
     ->group(function () {
         Route::post('/login', [AuthController::class, 'login'])
             ->name('login')
             ->middleware('throttle:' . AuthController::THROTTLE_LIMITER);
-        Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -106,6 +106,8 @@ Route::middleware('auth:sanctum')->group(function () {
 Route::prefix('auth')
     ->as('auth.')
     ->group(function () {
-        Route::post('/login', [AuthController::class, 'login'])->name('login');
+        Route::post('/login', [AuthController::class, 'login'])
+            ->name('login')
+            ->middleware('throttle:' . AuthController::THROTTLE_LIMITER);
         Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
     });

--- a/tests/Feature/CorsTest.php
+++ b/tests/Feature/CorsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+it('n\'autorise pas le joker comme origine CORS', function () {
+    // Une origine unique et explicite, jamais '*' : coupler '*' et
+    // supports_credentials laisse n'importe quel site lire les réponses authentifiées.
+    expect(config('cors.allowed_origins'))->not->toContain('*');
+});
+
+it('reflete uniquement l\'origine configuree, pas une origine etrangere', function () {
+    config()->set('cors.allowed_origins', ['https://promeb.example']);
+
+    $reponse = $this->call('OPTIONS', '/api/auth/login', [], [], [], [
+        'HTTP_ORIGIN'                         => 'https://evil.com',
+        'HTTP_ACCESS_CONTROL_REQUEST_METHOD'  => 'POST',
+    ]);
+
+    // L'origine étrangère ne doit PAS être renvoyée dans l'en-tête.
+    expect($reponse->headers->get('Access-Control-Allow-Origin'))->not->toBe('https://evil.com');
+});

--- a/tests/Feature/CreateUserPasswordTest.php
+++ b/tests/Feature/CreateUserPasswordTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('refuse un mot de passe de moins de 12 caracteres', function () {
+    $this->artisan('user:create', [
+        'name'     => 'Court',
+        'email'    => 'court@promeb.fr',
+        'password' => 'court',
+    ])->assertFailed();
+
+    expect(User::where('email', 'court@promeb.fr')->exists())->toBeFalse();
+});
+
+it('accepte un mot de passe de 12 caracteres ou plus', function () {
+    $this->artisan('user:create', [
+        'name'     => 'Correct',
+        'email'    => 'correct@promeb.fr',
+        'password' => 'motdepasse-solide',
+    ])->assertExitCode(0);
+
+    expect(User::where('email', 'correct@promeb.fr')->exists())->toBeTrue();
+});

--- a/tests/Feature/LoginThrottleTest.php
+++ b/tests/Feature/LoginThrottleTest.php
@@ -68,3 +68,15 @@ it('une connexion reussie remet le compteur a zero', function () {
             ->assertStatus(422);
     }
 });
+
+it('un email envoye en tableau ne fait pas planter le limiteur (422, pas 500)', function () {
+    // Le middleware `throttle:login` exécute la closure du limiteur - donc
+    // AuthController::cleThrottle() - AVANT la validation du contrôleur. Si
+    // `email` est un tableau, `(string) $request->input('email')` déclenchait
+    // un warning PHP converti en 500, et l'exception empêchait même `hit()`
+    // d'être appelé : la tentative n'était pas comptée (esquive du throttle).
+    $this->postJson('/api/auth/login', [
+        'email'    => ['a', 'b'],
+        'password' => 'mauvais',
+    ])->assertStatus(422);
+});

--- a/tests/Feature/LoginThrottleTest.php
+++ b/tests/Feature/LoginThrottleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('bloque la connexion apres 5 tentatives echouees (429 a la 6e)', function () {
+    User::factory()->create([
+        'email'    => 'victime@promeb.fr',
+        'password' => bcrypt('le-vrai-mot-de-passe'),
+    ]);
+
+    // 5 tentatives échouées : refusées (422), mais pas encore bloquées.
+    for ($i = 1; $i <= 5; $i++) {
+        $this->postJson('/api/auth/login', [
+            'email'    => 'victime@promeb.fr',
+            'password' => 'mauvais',
+        ])->assertStatus(422);
+    }
+
+    // La 6e est bloquée par le limiteur.
+    $this->postJson('/api/auth/login', [
+        'email'    => 'victime@promeb.fr',
+        'password' => 'mauvais',
+    ])->assertStatus(429);
+});
+
+it('ne bloque pas une autre adresse IP pour le meme email', function () {
+    User::factory()->create([
+        'email'    => 'victime@promeb.fr',
+        'password' => bcrypt('le-vrai-mot-de-passe'),
+    ]);
+
+    // 5 échecs depuis une première IP.
+    for ($i = 1; $i <= 5; $i++) {
+        $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.1'])
+            ->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+            ->assertStatus(422);
+    }
+
+    // Une IP différente sur le même email n'est pas bloquée : la clé (email+IP) change.
+    $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.2'])
+        ->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+        ->assertStatus(422);
+});
+
+it('une connexion reussie remet le compteur a zero', function () {
+    User::factory()->create([
+        'email'    => 'victime@promeb.fr',
+        'password' => bcrypt('le-bon-mot-de-passe'),
+    ]);
+
+    // 4 échecs.
+    for ($i = 1; $i <= 4; $i++) {
+        $this->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+            ->assertStatus(422);
+    }
+
+    // Une réussite doit effacer l'ardoise.
+    $this->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'le-bon-mot-de-passe'])
+        ->assertNoContent();
+
+    // Après quoi on doit pouvoir de nouveau échouer 5 fois sans être bloqué :
+    // si la remise à zéro n'a pas eu lieu, la 2e de ces tentatives (6e cumulée) serait un 429.
+    for ($i = 1; $i <= 5; $i++) {
+        $this->postJson('/api/auth/login', ['email' => 'victime@promeb.fr', 'password' => 'mauvais'])
+            ->assertStatus(422);
+    }
+});

--- a/tests/Feature/LogoutEffectiveTest.php
+++ b/tests/Feature/LogoutEffectiveTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('verifie que apres logout la route protegee repond 401', function () {
+    config(['sanctum.stateful' => ['testserver']]);
+
+    $user = User::factory()->create([
+        'email' => 'test@promeb.fr',
+        'password' => bcrypt('secret123'),
+    ]);
+
+    // Login réel (pas actingAs) pour obtenir un vrai cookie de session
+    $login = $this->withHeaders(['Origin' => 'http://testserver'])
+        ->postJson('/api/auth/login', [
+            'email' => 'test@promeb.fr',
+            'password' => 'secret123',
+        ]);
+    $login->assertNoContent();
+
+    // Route protégée accessible avec le cookie de session
+    $before = $this->withHeaders(['Origin' => 'http://testserver'])->getJson('/api/user');
+    $before->assertStatus(200);
+
+    // Logout
+    $logout = $this->withHeaders(['Origin' => 'http://testserver'])->postJson('/api/auth/logout');
+    $logout->assertNoContent();
+
+    // Le guard sanctum/web mémoïse l'utilisateur résolu au sein du process PHPUnit
+    // (RequestGuard::user() / AuthManager). Sans ce reset, l'appel suivant renverrait
+    // l'utilisateur mis en cache avant le logout, masquant une éventuelle régression.
+    // En production, chaque requête est un process séparé : aucune mémoïsation partagée.
+    $this->app['auth']->forgetGuards();
+
+    // Route protégée doit maintenant échouer
+    $after = $this->withHeaders(['Origin' => 'http://testserver'])->getJson('/api/user');
+    $after->assertStatus(401);
+});

--- a/tests/Feature/LogoutTest.php
+++ b/tests/Feature/LogoutTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('deconnecte un utilisateur authentifie', function () {
+    // Sanctum ne démarre une session que pour les requêtes "stateful" (Origin/Referer
+    // reconnu dans sanctum.stateful) — même technique que tests/Feature/SessionFixationTest.php.
+    // Sans cet en-tête, StartSession ne s'exécute jamais et $request->session() lève une
+    // exception avant l'assertion : non représentatif d'une vraie requête SPA (qui envoie
+    // toujours ce header), donc on le simule ici pour exercer le vrai chemin de code.
+    config(['sanctum.stateful' => ['testserver']]);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->withHeaders(['Origin' => 'http://testserver'])
+        ->postJson('/api/auth/logout')
+        ->assertNoContent();
+});
+
+it('repond 401 (et non 500) sur un logout sans session', function () {
+    $this->postJson('/api/auth/logout')
+        ->assertStatus(401);
+});

--- a/tests/Feature/SessionFixationTest.php
+++ b/tests/Feature/SessionFixationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('regenere l\'identifiant de session apres une connexion reussie (protection anti fixation de session)', function () {
+    // Sanctum ne démarre une session que pour les requêtes "stateful" (Origin/Referer
+    // reconnu dans sanctum.stateful). On force ce domaine pour que StartSession
+    // s'exécute réellement et que session()->regenerate() ait un effet à observer.
+    config(['sanctum.stateful' => ['testserver']]);
+
+    User::factory()->create([
+        'email'    => 'victime@promeb.fr',
+        'password' => bcrypt('le-bon-mot-de-passe'),
+    ]);
+
+    // Simule un attaquant qui a fixé l'identifiant de session de la victime avant
+    // l'authentification (attaque par fixation de session). L'ID doit être valide
+    // au sens d'Illuminate\Session\Store::isValidId() (40 caractères alphanumériques),
+    // sinon Laravel l'ignore et en génère un nouveau — ce qui rendrait le test inutile.
+    $idAttaquant = bin2hex(random_bytes(20));
+
+    $response = $this->withCredentials()
+        ->withCookie(config('session.cookie'), $idAttaquant)
+        ->withHeaders(['Origin' => 'http://testserver'])
+        ->postJson('/api/auth/login', [
+            'email'    => 'victime@promeb.fr',
+            'password' => 'le-bon-mot-de-passe',
+        ]);
+
+    $response->assertNoContent();
+
+    // Le store de session (array driver) est un singleton du conteneur applicatif :
+    // à l'issue de la requête, il porte encore l'ID courant de LA session traitée.
+    $idApresConnexion = $this->app['session']->getId();
+
+    expect($idApresConnexion)
+        ->not->toBe($idAttaquant)
+        ->and($idApresConnexion)->toHaveLength(40);
+});


### PR DESCRIPTION
Un audit de l'authentification (session Sanctum) a confirmé un socle sain — CSRF actif, pas d'IDOR sur le profil, fixation de session couverte, pas d'énumération de comptes — mais **cinq défauts serveur**, tous vérifiés en exerçant l'API réelle. Cette PR les corrige.

## Les corrections

**1. Rate limiting sur le login (critique).** Aucune limite n'existait : 30 tentatives en 9 s, aucun blocage. Ajout d'un `RateLimiter` nommé, 5 tentatives/minute, avec **remise à zéro au succès**. Blocage en 429 à la 6ᵉ tentative.

**2. CORS (critique).** `allowed_origins` était `['*']` **avec** `supports_credentials` — n'importe quel site pouvait lire les réponses authentifiées. Restreint à `FRONTEND_URL` (défaut `APP_URL`).

**3. Logout 401 au lieu de 500.** La route était hors du groupe authentifié ; un logout sans session plantait. Passée sous `auth:web,sanctum` (et non `auth:sanctum` seul, car le guard sanctum n'a pas de `logout()` — subtilité résolue).

**4. Mot de passe `min(12)`.** `user:create` acceptait 2 caractères, ce qui aurait sapé le point 1. Longueur seule, conforme NIST.

**5. Cookie `Secure` en prod.** `SESSION_SECURE_COOKIE=true` ajouté à `.env.production.example`.

## Ce que la revue a rattrapé — et corrigé

**Une régression que le lot introduisait lui-même** : un `email` envoyé en tableau (`email[]=a&email[]=b`) faisait planter la construction de la clé de throttle **avant** la validation → 500, et surtout **la tentative n'était pas comptée** — un attaquant esquivait ainsi le throttle qu'on venait d'ajouter. Corrigé : `cleThrottle` est robuste face à un email non-scalaire, et un test le prouve (500 avant, 422 après).

**Une promesse non tenue en production, désormais assumée.** Derrière Nginx sans `trustProxies`, `$request->ip()` renvoie l'IP du proxy — constante — donc le throttle `email + IP` dégénère en `email` seul en prod. L'anti-force-brute reste pleinement effectif ; seul le compromis anti-DoS-ciblé (le bénéfice du `+ IP`) n'est pas atteint tant que l'infra n'est pas configurée. **Décision : accepté tel quel pour l'instant**, avec :
- la spec rectifiée (note explicite sur le comportement réel en prod) ;
- un commentaire dans le code renvoyant au guide ;
- un **guide de mise à niveau** complet — `docs/securite/throttle-vraie-ip-client.md` — couvrant les trois couches (Nginx du VPS, Nginx du container, `trustProxies` Laravel), avec l'avertissement explicite de ne **jamais** faire confiance à tous les proxies (`at: '*'`), qui donnerait à l'attaquant le contrôle de `X-Forwarded-For`.

## Ce qui a été prouvé, pas supposé

- **Throttle** : bloque à la 6ᵉ, remise à zéro validée par mutation (casser le `clear` fait échouer le test).
- **Fixation de session** : un test prouve que l'ID de session change après connexion (mutation-validé).
- **Logout effectif** : `LogoutEffectiveTest` prouve qu'après logout, une route protégée répond 401 — validé par mutation (casser le logout fait échouer le test).
- **CORS** : une origine étrangère n'est pas reflétée ; config vide → origines fermées (sûr).
- `auth:web,sanctum` : prouvé sûr (dans cette app, sanctum ⊆ web, pas de `HasApiTokens`).

## Vérifications

- `php artisan test --testsuite=Feature` → **96 tests, 295 assertions**, verts.
- `npm run test` (front) → 53 verts, aucune régression (le lot ne touche pas le front).

## ⚠️ Rappel de déploiement

Deux variables sont dans les modèles `.env` mais devront être **reportées dans le vrai `.env` du VPS** au déploiement, sans quoi ces corrections n'ont pas d'effet en prod :
- `FRONTEND_URL=https://promeb.hotel-longchamps.fr`
- `SESSION_SECURE_COOKIE=true`

## Hors périmètre (lot front à venir)

Intercepteur axios sur 401, revalidation de session (état « connecté fantôme »), message de login en français, HSTS sur le reverse proxy.

Spec et plan : `docs/superpowers/specs/2026-07-14-securite-auth-serveur-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h37Y5aCqVVFZVYJnuKVaj